### PR TITLE
Response time measurement in HttpTest

### DIFF
--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/HttpTest.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/HttpTest.java
@@ -424,6 +424,13 @@ public class HttpTest extends SlimFixtureWithMap {
     }
 
     /**
+     * @return response time in ms for call to service.
+     */
+    public long responseTime() {
+        return getResponse().getResponseTime();
+    }
+
+    /**
      * @return http status received in response to last request.
      */
     public int responseStatus() {

--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/HttpTest.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/HttpTest.java
@@ -19,7 +19,7 @@ public class HttpTest extends SlimFixtureWithMap {
     /** Default content type for posts and puts. */
     public final static String DEFAULT_POST_CONTENT_TYPE = "application/x-www-form-urlencoded; charset=UTF-8";
 
-    private final Map<String, Object> headerValues = new LinkedHashMap<String, Object>();
+    private final Map<String, Object> headerValues = new LinkedHashMap<>();
     private HttpResponse response = createResponse();
     private String template;
     private String contentType = DEFAULT_POST_CONTENT_TYPE;

--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/TimerFixture.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/TimerFixture.java
@@ -1,0 +1,132 @@
+package nl.hsac.fitnesse.fixture.slim;
+
+import org.apache.commons.lang3.time.StopWatch;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Fixture to track time during a test.
+ */
+public class TimerFixture extends SlimFixture {
+    private final static Map<String, StopWatch> STOP_WATCHES = new LinkedHashMap<>();
+    private final static String DEFAULT_STOP_WATCH = "default";
+
+    /**
+     * Starts (possibly replacing) default timer.
+     */
+    public void startTimer() {
+        startTimer(DEFAULT_STOP_WATCH);
+    }
+
+    /**
+     * Starts (possibly replacing) named timer.
+     * @param name name to timer to create.
+     */
+    public void startTimer(String name) {
+        StopWatch sw = new StopWatch();
+        sw.start();
+        STOP_WATCHES.put(name, sw);
+    }
+
+    /**
+     * Stops default timer.
+     * @return time in milliseconds since timer was started.
+     */
+    public long stopTimer() {
+        return stopTimer(DEFAULT_STOP_WATCH);
+    }
+
+    /**
+     * Stops named timer.
+     * @param name name of timer to stop.
+     * @return time in milliseconds since timer was started.
+     */
+    public long stopTimer(String name) {
+        StopWatch sw = getStopWatch(name);
+        sw.stop();
+        STOP_WATCHES.remove(name);
+        return sw.getTime();
+    }
+
+    /**
+     * @return time in milliseconds since timer was started.
+     */
+    public long timeOnTimer() {
+        return timeOnTimer(DEFAULT_STOP_WATCH);
+    }
+
+    /**
+     * @param name name of timer to get time from.
+     * @return time in milliseconds since timer was started.
+     */
+    public long timeOnTimer(String name) {
+        return getStopWatch(name).getTime();
+    }
+
+    /**
+     * Pauses default timer (stopping measurement), can be resumed later.
+     * @return time in milliseconds since timer was started.
+     */
+    public long pauseTimer() {
+        return pauseTimer(DEFAULT_STOP_WATCH);
+    }
+
+    /**
+     * Pauses named timer (stopping measurement), can be resumed later.
+     * @param name name of timer to pause.
+     * @return time in milliseconds since timer was started.
+     */
+    public long pauseTimer(String name) {
+        StopWatch sw = getStopWatch(name);
+        sw.suspend();
+        return sw.getTime();
+    }
+
+    /**
+     * Resumes default timer (after it was paused).
+     */
+    public void resumeTimer() {
+        resumeTimer(DEFAULT_STOP_WATCH);
+    }
+
+    /**
+     * Resumes named timer (after it was paused).
+     * @param name name of timer to resume.
+     */
+    public void resumeTimer(String name) {
+        StopWatch sw = getStopWatch(name);
+        sw.resume();
+    }
+
+    /**
+     * @return all running timers and their current times (in ms).
+     */
+    public Map<String, Long> allTimerTimes() {
+        Map<String, Long> result = new LinkedHashMap<>();
+        for (Map.Entry<String, StopWatch> entry: STOP_WATCHES.entrySet()) {
+            String key = entry.getKey();
+            long time = entry.getValue().getTime();
+            result.put(key, time);
+        }
+        return result;
+    }
+
+    /**
+     * Stops all running timers.
+     * @return all stopped timers and their current times (in ms).
+     */
+    public Map<String, Long> stopAllTimers() {
+        Map<String, Long> result = allTimerTimes();
+        STOP_WATCHES.clear();
+        return result;
+    }
+
+    protected StopWatch getStopWatch(String name) {
+        StopWatch stopWatch = STOP_WATCHES.get(name);
+        if (stopWatch == null) {
+            throw new SlimFixtureException(false, "No timer found with name: " + name);
+        }
+        return stopWatch;
+    }
+}

--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/TimerFixture.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/TimerFixture.java
@@ -2,7 +2,10 @@ package nl.hsac.fitnesse.fixture.slim;
 
 import org.apache.commons.lang3.time.StopWatch;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -128,5 +131,40 @@ public class TimerFixture extends SlimFixture {
             throw new SlimFixtureException(false, "No timer found with name: " + name);
         }
         return stopWatch;
+    }
+
+    /**
+     * @return current system time.
+     */
+    public String currentSystemTime() {
+        return currentSystemTimeAs("HH:mm:ss.SSS");
+    }
+
+    /**
+     * @param format to return time (and possibly date) in.
+     * @return current system time formatted according to format.
+     */
+    public String currentSystemTimeAs(String format) {
+        Locale locale = Locale.getDefault();
+        return formatCurrentSystemTime(format, locale);
+    }
+
+    /**
+     * @param format to return time (and possibly date) in.
+     * @param languageTag language to use when formatting.
+     * @return current system time formatted according to format.
+     */
+    public String currentSystemTimeAsIn(String format, String languageTag) {
+        Locale locale = Locale.forLanguageTag(languageTag);
+        return formatCurrentSystemTime(format, locale);
+    }
+
+    private String formatCurrentSystemTime(String format, Locale locale) {
+        Date now = new Date();
+        try {
+            return new SimpleDateFormat(format, locale).format(now);
+        } catch (IllegalArgumentException e) {
+            throw new SlimFixtureException(false, "Bad date format: " + format);
+        }
     }
 }

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/HttpClient.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/HttpClient.java
@@ -117,6 +117,8 @@ public class HttpClient {
     }
 
     protected void getResponse(String url, HttpResponse response, HttpRequestBase method, Map<String, Object> headers) {
+        long startTime = 0;
+        long endTime = -1;
         try {
             if (headers != null) {
                 for (String key : headers.keySet()) {
@@ -129,11 +131,15 @@ public class HttpClient {
 
             org.apache.http.HttpResponse resp;
             CookieStore store = response.getCookieStore();
+
+            startTime = currentTimeMillis();
             if (store == null) {
                 resp = getHttpResponse(url, method);
             } else {
                 resp = getHttpResponse(store, url, method);
             }
+            endTime = currentTimeMillis();
+
             int returnCode = resp.getStatusLine().getStatusCode();
             response.setStatusCode(returnCode);
             HttpEntity entity = resp.getEntity();
@@ -162,6 +168,12 @@ public class HttpClient {
         } catch (Exception e) {
             throw new RuntimeException("Unable to get response from: " + url, e);
         } finally {
+            if (startTime > 0) {
+                if (endTime < 0) {
+                    endTime = currentTimeMillis();
+                }
+            }
+            response.setResponseTime(endTime - startTime);
             method.reset();
         }
     }
@@ -194,5 +206,9 @@ public class HttpClient {
 
     protected org.apache.http.HttpResponse getHttpResponse(String url, HttpRequestBase method) throws IOException {
         return HTTP_CLIENT.execute(method);
+    }
+
+    protected long currentTimeMillis() {
+        return System.currentTimeMillis();
     }
 }

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/HttpResponse.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/HttpResponse.java
@@ -18,6 +18,7 @@ public class HttpResponse {
     protected String response;
     private int statusCode;
     private CookieStore cookieStore;
+    private long responseTime = -1;
 
     /**
      * @throws RuntimeException if no valid response is available
@@ -93,6 +94,21 @@ public class HttpResponse {
      */
     public void setCookieStore(CookieStore cookieStore) {
         this.cookieStore = cookieStore;
+    }
+
+    /**
+     * @return response time in ms for call.
+     */
+    public long getResponseTime() {
+        return responseTime;
+    }
+
+    /**
+     * Sets response time for obtaining this response.
+     * @param responseTime response time in ms for call.
+     */
+    public void setResponseTime(long responseTime) {
+        this.responseTime = responseTime;
     }
 
     @Override

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/HttpResponse.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/HttpResponse.java
@@ -11,9 +11,9 @@ import java.util.concurrent.ConcurrentHashMap;
  * Wrapper around HTTP response (and request).
  */
 public class HttpResponse {
-    private final static Map<String, HttpResponse> INSTANCES = new ConcurrentHashMap<String, HttpResponse>();
+    private final static Map<String, HttpResponse> INSTANCES = new ConcurrentHashMap<>();
 
-    private Map<String, String> responseHeaders = new HashMap<String, String>();
+    private Map<String, String> responseHeaders = new HashMap<>();
     private String request;
     protected String response;
     private int statusCode;

--- a/wiki/FitNesseRoot/HsacAcceptanceTests/SlimTests/HttpTest/XmlHttpTest/content.txt
+++ b/wiki/FitNesseRoot/HsacAcceptanceTests/SlimTests/HttpTest/XmlHttpTest/content.txt
@@ -28,28 +28,30 @@ Incomplete address: no zip code</PO:confirmation>
 |add response|{{{<binary/>}}}    |
 |$url=       |get mock server url|
 
-|script   |xml http test                                                                                                                                 |
-|post     |{{{<Hallo/>}}} |to                                          |$url                                                                             |
-|check    |xPath          |count(/dag)                                 |1                                                                                |
-|reject   |post           |{{{<ClientFault/>}}}                        |to                                          |$url                                |
-|show     |response                                                                                                                                      |
-|check    |response status|500                                                                                                                           |
-|check    |raw xPath      |/env:Envelope/env:Body/env:Fault/faultstring|Message does not have necessary info                                             |
-|show     |response headers                                                                                                                              |
-|check    |response header|Content-length                              |556                                                                              |
-|note     |next line is commented out so we won't have a real exception, uncomment to see that SOAP content is shown in exception                        |
-|note     |check          |xPath                                       |/env:Envelope/env:Body/env:Fault/faultstring|Message does not have necessary info|
-|reject   |post           |{{{<ServerFault/>}}}                        |to                                          |$url                                |
-|show     |response                                                                                                                                      |
-|check    |response status|500                                                                                                                           |
-|check    |raw xPath      |/env:Envelope/env:Body/env:Fault/faultstring|Message does not have necessary info                                             |
-|note     |next line is commented out so we won't have a real exception, uncomment to see that SOAP content is shown in exception                        |
-|note     |check          |xPath                                       |/env:Envelope/env:Body/env:Fault/faultstring|Message does not have necessary info|
-|reject   |post           |{{{<NoXml/>}}}                              |to                                          |$url                                |
-|check    |response status|200                                                                                                                           |
-|check    |response       |<no xml                                                                                                                       |
-|note     |next line is commented out so we won't have a real exception, uncomment to see that non-XML content is shown in exception                     |
-|note     |check          |xPath                                       |count(/*)                                   |0                                   |
+|script|xml http test                                                                                                                                 |
+|check |response time  |-1                                                                                                                            |
+|post  |{{{<Hallo/>}}} |to                                          |$url                                                                             |
+|check |xPath          |count(/dag)                                 |1                                                                                |
+|check |response time  |>0                                                                                                                            |
+|reject|post           |{{{<ClientFault/>}}}                        |to                                          |$url                                |
+|show  |response                                                                                                                                      |
+|check |response status|500                                                                                                                           |
+|check |raw xPath      |/env:Envelope/env:Body/env:Fault/faultstring|Message does not have necessary info                                             |
+|show  |response headers                                                                                                                              |
+|check |response header|Content-length                              |556                                                                              |
+|note  |next line is commented out so we won't have a real exception, uncomment to see that SOAP content is shown in exception                        |
+|note  |check          |xPath                                       |/env:Envelope/env:Body/env:Fault/faultstring|Message does not have necessary info|
+|reject|post           |{{{<ServerFault/>}}}                        |to                                          |$url                                |
+|show  |response                                                                                                                                      |
+|check |response status|500                                                                                                                           |
+|check |raw xPath      |/env:Envelope/env:Body/env:Fault/faultstring|Message does not have necessary info                                             |
+|note  |next line is commented out so we won't have a real exception, uncomment to see that SOAP content is shown in exception                        |
+|note  |check          |xPath                                       |/env:Envelope/env:Body/env:Fault/faultstring|Message does not have necessary info|
+|reject|post           |{{{<NoXml/>}}}                              |to                                          |$url                                |
+|check |response status|200                                                                                                                           |
+|check |response       |<no xml                                                                                                                       |
+|note  |next line is commented out so we won't have a real exception, uncomment to see that non-XML content is shown in exception                     |
+|note  |check          |xPath                                       |count(/*)                                   |0                                   |
 
 |table: Mock Server Message Report|
 

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/content.txt
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/content.txt
@@ -35,6 +35,7 @@ The main commands/keywords (i.e. public methods) offered by !-nl.hsac.fitnesse.f
 |response                           |Returns the last response body returned. Intended to be used in combination with the 'show' or 'check' commands.                                                      |
 |html response                      |Returns the last response body returned as HTML to be embedded in the test result table (in combination with the 'show' command).                                     |
 |response status                    |HTTP status code of last response received.                                                                                                                           |
+|response time                      |Time (in milliseconds) it took to send the last request and receive its response.                                                                                     |
 |response headers                   |HTTP headers received with last response.                                                                                                                             |
 |response header <name>             |Value of HTTP header 'name' in last response received.                                                                                                                |
 |response is valid                  |Whether the last request was successful, or an error.                                                                                                                 |

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/UtilityFixtures/TimerFixture/content.txt
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/UtilityFixtures/TimerFixture/content.txt
@@ -51,3 +51,13 @@ We can get information on all timers.
 |start timer|test 9         |
 |show       |all timer times|
 |show       |stop all timers|
+
+We can get the current system time, possibly specifying a format (the format is the format string used by [[Java's !-SimpleDateFormat-!][http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html]], also used by '!-!today-!') to use.
+The difference between these methods and !-!today-! is that the latter is evaluated when the test is started, these methods return the time at the moment the test executes them.
+
+|script|timer fixture                                                         |
+|show  |current system time                                                   |
+|show  |current system time as|HH:MM:ss.SSS                                   |
+|show  |current system time as|E dd-MMM-yy HH:mm:ss.SSS                       |
+|show  |current system time as|E dd-MMM-yy HH:mm:ss.SSS|in|ja-JP-x-lvariant-JP|
+

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/UtilityFixtures/TimerFixture/content.txt
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/UtilityFixtures/TimerFixture/content.txt
@@ -17,7 +17,7 @@ We can start and use a timer with a name.
 |script     |timer fixture                |
 |start timer|test                         |
 |wait       |1            |seconds        |
-|check      |time on timer|test|> 1000    |
+|check      |time on timer|test|>= 1000   |
 |$elapsed=  |time on timer|test           |
 |check      |stop timer   |test|>=$elapsed|
 |start timer|test2                        |

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/UtilityFixtures/TimerFixture/content.txt
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/UtilityFixtures/TimerFixture/content.txt
@@ -1,0 +1,53 @@
+Timer fixture is intended to be used as [[library][.FitNesse.UserGuide.WritingAcceptanceTests.SliM.LibraryTable]].
+
+All times reported are in milliseconds, resume can only be done after pause. After stopping a timer it is no longer available.
+
+We can start and use a timer without a name.
+
+|script   |timer fixture             |
+|start timer                         |
+|wait     |5            |milliseconds|
+|check    |time on timer|>= 5        |
+|$elapsed=|time on timer             |
+|wait     |1            |milliseconds|
+|check    |stop timer   |>$elapsed   |
+
+We can start and use a timer with a name.
+
+|script     |timer fixture                |
+|start timer|test                         |
+|wait       |1            |seconds        |
+|check      |time on timer|test|> 1000    |
+|$elapsed=  |time on timer|test           |
+|check      |stop timer   |test|>=$elapsed|
+|start timer|test2                        |
+
+We can use a timer with a name started in another script table.
+
+|script   |timer fixture                 |
+|wait     |1            |milliseconds    |
+|check    |time on timer|test2|> 0       |
+|$elapsed=|time on timer|test2           |
+|check    |stop timer   |test2|>=$elapsed|
+
+We pause and resume timers
+|script      |timer fixture                  |
+|start timer |to Pause                       |
+|wait        |1            |milliseconds     |
+|check       |pause timer  |to Pause|>=1     |
+|$paused=    |time on timer|to Pause         |
+|wait        |1            |milliseconds     |
+|check       |time on timer|to Pause|$paused |
+|resume timer|to Pause                       |
+|wait        |1            |milliseconds     |
+|check       |time on timer|to Pause|>$paused|
+
+
+We can get information on all timers.
+
+|script     |timer fixture  |
+|start timer                |
+|start timer|test 8         |
+|start timer|test 9         |
+|show       |all timer times|
+|show       |stop all timers|

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/UtilityFixtures/TimerFixture/properties.xml
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/UtilityFixtures/TimerFixture/properties.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit>true</Edit>
+<Files>true</Files>
+<Help>Fixture to assist in measuring time during test</Help>
+<Properties>true</Properties>
+<RecentChanges>true</RecentChanges>
+<Refactor>true</Refactor>
+<Search>true</Search>
+<Test>true</Test>
+<Versions>true</Versions>
+<WhereUsed>true</WhereUsed>
+</properties>


### PR DESCRIPTION
Adds request handling time to Http Test. And new utility fixture to measure elapsed time (and output current time) during test: `TimerFixture` 