### PR TITLE
HttpTest can work with cookies

### DIFF
--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/HttpTest.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/HttpTest.java
@@ -555,6 +555,14 @@ public class HttpTest extends SlimFixtureWithMap {
 
     /**
      * @param cookieName name of cookie.
+     * @return whether cookie in the cookie store is http-only (not accessible to Javascript).
+     */
+    public Boolean cookieIsHttpOnly(String cookieName) {
+        return cookieAttribute(cookieName, "httponly") != null;
+    }
+
+    /**
+     * @param cookieName name of cookie.
      * @param attributeName name of attribute.
      * @return value of attribute for cookie.
      */

--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/HttpTest.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/HttpTest.java
@@ -499,6 +499,13 @@ public class HttpTest extends SlimFixtureWithMap {
         return result;
     }
 
+    /**
+     * Removes all cookies from the cookie store.
+     */
+    public void clearCookies() {
+        getResponse().getCookieStore().clear();
+    }
+
     protected HttpResponse getResponse() {
         return response;
     }

--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/HttpTest.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/HttpTest.java
@@ -446,7 +446,8 @@ public class HttpTest extends SlimFixtureWithMap {
 
     /**
      * @param headerName name of response header.
-     * @return value of header in last response.
+     * @return value of header in last response (may be a list if the saame header name was sent multiple times
+     * (e.g. Set-Cookie).
      */
     public Object responseHeader(String headerName) {
         return responseHeaders().get(headerName);

--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/HttpTest.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/HttpTest.java
@@ -5,12 +5,14 @@ import nl.hsac.fitnesse.fixture.util.HttpResponse;
 import org.apache.http.client.CookieStore;
 import org.apache.http.cookie.Cookie;
 import org.apache.http.impl.client.BasicCookieStore;
+import org.apache.http.impl.cookie.BasicClientCookie;
 
 import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -547,6 +549,20 @@ public class HttpTest extends SlimFixtureWithMap {
         Cookie cookie = getCookie(cookieName);
         if (cookie != null) {
             result = cookie.isSecure();
+        }
+        return result;
+    }
+
+    /**
+     * @param cookieName name of cookie.
+     * @param attributeName name of attribute.
+     * @return value of attribute for cookie.
+     */
+    public String cookieAttribute(String cookieName, String attributeName) {
+        String result = null;
+        Cookie cookie = getCookie(cookieName);
+        if (cookie instanceof BasicClientCookie) {
+            result = ((BasicClientCookie) cookie).getAttribute(attributeName.toLowerCase(Locale.ENGLISH));
         }
         return result;
     }

--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/HttpTest.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/HttpTest.java
@@ -492,11 +492,67 @@ public class HttpTest extends SlimFixtureWithMap {
      */
     public String cookieValue(String cookieName) {
         String result = null;
-        Cookie cookie = getResponse().getCookieNamed(cookieName);
+        Cookie cookie = getCookie(cookieName);
         if (cookie != null) {
             result = cookie.getValue();
         }
         return result;
+    }
+
+    /**
+     * @param cookieName name of cookie.
+     * @return domain of cookie in the cookie store.
+     */
+    public String cookieDomain(String cookieName) {
+        String result = null;
+        Cookie cookie = getCookie(cookieName);
+        if (cookie != null) {
+            result = cookie.getDomain();
+        }
+        return result;
+    }
+
+    /**
+     * @param cookieName name of cookie.
+     * @return path of cookie in the cookie store.
+     */
+    public String cookiePath(String cookieName) {
+        String result = null;
+        Cookie cookie = getCookie(cookieName);
+        if (cookie != null) {
+            result = cookie.getPath();
+        }
+        return result;
+    }
+
+    /**
+     * @param cookieName name of cookie.
+     * @return whether cookie in the cookie store is persistent.
+     */
+    public Boolean cookieIsPersistent(String cookieName) {
+        Boolean result = null;
+        Cookie cookie = getCookie(cookieName);
+        if (cookie != null) {
+            result = cookie.isPersistent();
+        }
+        return result;
+    }
+
+    /**
+     * @param cookieName name of cookie.
+     * @return whether cookie in the cookie store requires a secure connection.
+     */
+    public Boolean cookieIsSecure(String cookieName) {
+        Boolean result = null;
+        Cookie cookie = getCookie(cookieName);
+        if (cookie != null) {
+            result = cookie.isSecure();
+        }
+        return result;
+    }
+
+    private Cookie getCookie(String cookieName) {
+        return getResponse().getCookieNamed(cookieName);
     }
 
     /**

--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/HttpTest.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/HttpTest.java
@@ -440,7 +440,7 @@ public class HttpTest extends SlimFixtureWithMap {
     /**
      * @return headers received with response to last request.
      */
-    public Map<String, String> responseHeaders() {
+    public Map<String, Object> responseHeaders() {
         return response.getResponseHeaders();
     }
 
@@ -448,7 +448,7 @@ public class HttpTest extends SlimFixtureWithMap {
      * @param headerName name of response header.
      * @return value of header in last response.
      */
-    public String responseHeader(String headerName) {
+    public Object responseHeader(String headerName) {
         return responseHeaders().get(headerName);
     }
 

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/HttpClient.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/HttpClient.java
@@ -22,6 +22,9 @@ import org.apache.http.util.EntityUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 /**
  * Helper to make Http calls and get response.
@@ -179,7 +182,24 @@ public class HttpClient {
         for (Header h : respHeaders) {
             String headerName = h.getName();
             String headerValue = h.getValue();
-            responseHeaders.put(headerName, headerValue);
+            if (responseHeaders.containsKey(headerName)) {
+                handleRepeatedHeaderValue(responseHeaders, headerName, headerValue);
+            } else {
+                responseHeaders.put(headerName, headerValue);
+            }
+        }
+    }
+
+    protected void handleRepeatedHeaderValue(Map<String, Object> responseHeaders,
+                                             String headerName, String headerValue) {
+        Object previousHeaderValue = responseHeaders.get(headerName);
+        if (previousHeaderValue instanceof Collection) {
+            ((Collection) previousHeaderValue).add(headerValue);
+        } else {
+            List<Object> valueList = new ArrayList();
+            valueList.add(previousHeaderValue);
+            valueList.add(headerValue);
+            responseHeaders.put(headerName, valueList);
         }
     }
 

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/HttpClient.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/HttpClient.java
@@ -144,7 +144,7 @@ public class HttpClient {
             response.setStatusCode(returnCode);
             HttpEntity entity = resp.getEntity();
 
-            Map<String, String> responseHeaders = response.getResponseHeaders();
+            Map<String, Object> responseHeaders = response.getResponseHeaders();
             for (Header h : resp.getAllHeaders()) {
                 responseHeaders.put(h.getName(), h.getValue());
             }

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/HttpClient.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/HttpClient.java
@@ -144,10 +144,7 @@ public class HttpClient {
             response.setStatusCode(returnCode);
             HttpEntity entity = resp.getEntity();
 
-            Map<String, Object> responseHeaders = response.getResponseHeaders();
-            for (Header h : resp.getAllHeaders()) {
-                responseHeaders.put(h.getName(), h.getValue());
-            }
+            copyHeaders(response.getResponseHeaders(), resp.getAllHeaders());
 
             if (entity == null) {
                 response.setResponse(null);
@@ -175,6 +172,14 @@ public class HttpClient {
             }
             response.setResponseTime(endTime - startTime);
             method.reset();
+        }
+    }
+
+    protected void copyHeaders(Map<String, Object> responseHeaders, Header[] respHeaders) {
+        for (Header h : respHeaders) {
+            String headerName = h.getName();
+            String headerValue = h.getValue();
+            responseHeaders.put(headerName, headerValue);
         }
     }
 

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/HttpResponse.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/HttpResponse.java
@@ -2,6 +2,7 @@ package nl.hsac.fitnesse.fixture.util;
 
 import org.apache.http.HttpStatus;
 import org.apache.http.client.CookieStore;
+import org.apache.http.cookie.Cookie;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -86,6 +87,23 @@ public class HttpResponse {
      */
     public CookieStore getCookieStore() {
         return cookieStore;
+    }
+
+    /**
+     * @param cookieName name of cookie to be found in cookie store
+     * @return cookie found, if any, null otherwise.
+     */
+    public Cookie getCookieNamed(String cookieName) {
+        Cookie result = null;
+        if (cookieStore != null) {
+            for (Cookie cookie : getCookieStore().getCookies()) {
+                if (cookieName.equals(cookie.getName())) {
+                    result = cookie;
+                    break;
+                }
+            }
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/HttpResponse.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/HttpResponse.java
@@ -3,7 +3,7 @@ package nl.hsac.fitnesse.fixture.util;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.CookieStore;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -13,7 +13,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class HttpResponse {
     private final static Map<String, HttpResponse> INSTANCES = new ConcurrentHashMap<>();
 
-    private Map<String, String> responseHeaders = new HashMap<>();
+    private Map<String, Object> responseHeaders = new LinkedHashMap<>();
     private String request;
     protected String response;
     private int statusCode;
@@ -77,7 +77,7 @@ public class HttpResponse {
     /**
      * @return headers in response.
      */
-    public Map<String, String> getResponseHeaders() {
+    public Map<String, Object> getResponseHeaders() {
         return responseHeaders;
     }
 

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/HttpCookieHandling/content.txt
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/HttpCookieHandling/content.txt
@@ -38,6 +38,7 @@ By setting 'store cookies' to 'true' we can ensure cookies are stored, and sent 
 |check            |cookie         |uaid|path     |/                |
 |reject           |cookie         |uaid|is persistent              |
 |ensure           |cookie         |uaid|is secure                  |
+|ensure           |cookie         |uaid|is http only               |
 |check            |cookie         |uaid|attribute|HTTPOnly    |!--!|
 |check            |cookie         |uaid|attribute|doesNotExist|null|
 

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/HttpCookieHandling/content.txt
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/HttpCookieHandling/content.txt
@@ -16,24 +16,28 @@ By default http test ignores 'Set-Cookie' headers (i.e. cookies received are not
 
 By setting 'store cookies' to 'true' we can ensure cookies are stored, and sent with subsequent requests.
 
-|script           |http test                |
-|set store cookies|true                     |
-|get from         |${URL_THAT_SENDS_COOKIES}|
-|check            |response status|200      |
-|show             |response headers         |
-|show             |cookie values            |
-|check not        |cookie value   |uaid|null|
-|get from         |${URL_THAT_SENDS_COOKIES}|
-|check            |response status|200      |
-|show             |response headers         |
-|show             |cookie values            |
-|check not        |cookie value   |uaid|null|
-|clear cookies                              |
-|get from         |${URL_THAT_SENDS_COOKIES}|
-|check            |response status|200      |
-|show             |response headers         |
-|show             |cookie values            |
-|check not        |cookie value   |uaid|null|
+|script           |http test                                 |
+|set store cookies|true                                      |
+|get from         |${URL_THAT_SENDS_COOKIES}                 |
+|check            |response status|200                       |
+|show             |response headers                          |
+|show             |cookie values                             |
+|check not        |cookie value   |uaid|null                 |
+|get from         |${URL_THAT_SENDS_COOKIES}                 |
+|check            |response status|200                       |
+|show             |response headers                          |
+|show             |cookie values                             |
+|check not        |cookie value   |uaid|null                 |
+|clear cookies                                               |
+|get from         |${URL_THAT_SENDS_COOKIES}                 |
+|check            |response status|200                       |
+|show             |response headers                          |
+|show             |cookie values                             |
+|check not        |cookie         |uaid|value |null          |
+|check            |cookie         |uaid|domain|login.live.com|
+|check            |cookie         |uaid|path  |/             |
+|reject           |cookie         |uaid|is persistent        |
+|ensure           |cookie         |uaid|is secure            |
 
 If we set 'store cookies' to 'false' cookies are no longer stored.
 

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/HttpCookieHandling/content.txt
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/HttpCookieHandling/content.txt
@@ -16,28 +16,30 @@ By default http test ignores 'Set-Cookie' headers (i.e. cookies received are not
 
 By setting 'store cookies' to 'true' we can ensure cookies are stored, and sent with subsequent requests.
 
-|script           |http test                                 |
-|set store cookies|true                                      |
-|get from         |${URL_THAT_SENDS_COOKIES}                 |
-|check            |response status|200                       |
-|show             |response headers                          |
-|show             |cookie values                             |
-|check not        |cookie value   |uaid|null                 |
-|get from         |${URL_THAT_SENDS_COOKIES}                 |
-|check            |response status|200                       |
-|show             |response headers                          |
-|show             |cookie values                             |
-|check not        |cookie value   |uaid|null                 |
-|clear cookies                                               |
-|get from         |${URL_THAT_SENDS_COOKIES}                 |
-|check            |response status|200                       |
-|show             |response headers                          |
-|show             |cookie values                             |
-|check not        |cookie         |uaid|value |null          |
-|check            |cookie         |uaid|domain|login.live.com|
-|check            |cookie         |uaid|path  |/             |
-|reject           |cookie         |uaid|is persistent        |
-|ensure           |cookie         |uaid|is secure            |
+|script           |http test                                       |
+|set store cookies|true                                            |
+|get from         |${URL_THAT_SENDS_COOKIES}                       |
+|check            |response status|200                             |
+|show             |response headers                                |
+|show             |cookie values                                   |
+|check not        |cookie value   |uaid|null                       |
+|get from         |${URL_THAT_SENDS_COOKIES}                       |
+|check            |response status|200                             |
+|show             |response headers                                |
+|show             |cookie values                                   |
+|check not        |cookie value   |uaid|null                       |
+|clear cookies                                                     |
+|get from         |${URL_THAT_SENDS_COOKIES}                       |
+|check            |response status|200                             |
+|show             |response headers                                |
+|show             |cookie values                                   |
+|check not        |cookie         |uaid|value    |null             |
+|check            |cookie         |uaid|domain   |login.live.com   |
+|check            |cookie         |uaid|path     |/                |
+|reject           |cookie         |uaid|is persistent              |
+|ensure           |cookie         |uaid|is secure                  |
+|check            |cookie         |uaid|attribute|HTTPOnly    |!--!|
+|check            |cookie         |uaid|attribute|doesNotExist|null|
 
 If we set 'store cookies' to 'false' cookies are no longer stored.
 

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/HttpCookieHandling/content.txt
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/HttpCookieHandling/content.txt
@@ -1,0 +1,32 @@
+By default http test ignores 'Set-Cookie' headers (i.e. cookies received are not sent with subsequent requests). 
+
+!define URL_THAT_SENDS_COOKIES {https://mail.live.com/default.aspx}
+
+|script     |http test                        |
+|get from   |${URL_THAT_SENDS_COOKIES}        |
+|check      |response status   |200           |
+|show       |response headers                 |
+|note       |By default cookies are not stored|
+|check      |cookie value      |uaid   |null  |
+|$setCookie=|response header   |Set-Cookie    |
+
+|script|list fixture                     |
+|check |size of |$setCookie|>1           |
+|show  |value at|2         |in|$setCookie|
+
+By setting 'store cookies' to 'true' we can ensure cookies are stored, and sent with subsequent requests.
+
+|script           |http test                |
+|set store cookies|true                     |
+|get from         |${URL_THAT_SENDS_COOKIES}|
+|check            |response status|200      |
+|show             |response headers         |
+|show             |cookie values            |
+|check not        |cookie value   |uaid|null|
+|get from         |${URL_THAT_SENDS_COOKIES}|
+|check            |response status|200      |
+|show             |response headers         |
+|show             |cookie values            |
+
+
+

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/HttpCookieHandling/content.txt
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/HttpCookieHandling/content.txt
@@ -27,6 +27,20 @@ By setting 'store cookies' to 'true' we can ensure cookies are stored, and sent 
 |check            |response status|200      |
 |show             |response headers         |
 |show             |cookie values            |
+|check not        |cookie value   |uaid|null|
+|clear cookies                              |
+|get from         |${URL_THAT_SENDS_COOKIES}|
+|check            |response status|200      |
+|show             |response headers         |
+|show             |cookie values            |
+|check not        |cookie value   |uaid|null|
 
+If we set 'store cookies' to 'false' cookies are no longer stored.
 
+|script                                     |
+|set store cookies|false                    |
+|get from         |${URL_THAT_SENDS_COOKIES}|
+|check            |response status|200      |
+|show             |response headers         |
+|check            |cookie value   |uaid|null|
 

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/HttpCookieHandling/properties.xml
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/HttpCookieHandling/properties.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<properties>
+<Edit>true</Edit>
+<Files>true</Files>
+<Properties>true</Properties>
+<RecentChanges>true</RecentChanges>
+<Refactor>true</Refactor>
+<Search>true</Search>
+<Test>true</Test>
+<Versions>true</Versions>
+<WhereUsed>true</WhereUsed>
+</properties>

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/HttpGetFollowRedirectTest/content.txt
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/HttpGetFollowRedirectTest/content.txt
@@ -14,4 +14,3 @@ Then we do the same call without following the redirect, allowing us to inspect 
 |check   |response status|301                                            |
 |check   |response header|Location|!-https://mail.live.com/default.aspx-!|
 |show    |response                                                       |
-|show    |response headers                                               |

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/HttpGetFollowRedirectTest/content.txt
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/HttpGetFollowRedirectTest/content.txt
@@ -5,6 +5,7 @@ First we do a 'normal' GET to ${REDIRECT_URL}, which will redirect us.
 |script  |http test          |
 |get from|${REDIRECT_URL}    |
 |check   |response status|200|
+|show    |response headers   |
 
 Then we do the same call without following the redirect, allowing us to inspect that a redirect is sent and what the redirect location is.
 
@@ -13,3 +14,4 @@ Then we do the same call without following the redirect, allowing us to inspect 
 |check   |response status|301                                            |
 |check   |response header|Location|!-https://mail.live.com/default.aspx-!|
 |show    |response                                                       |
+|show    |response headers                                               |

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/HttpPost3UsingFreemarkerTemplateTest/content.txt
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/HttpPost3UsingFreemarkerTemplateTest/content.txt
@@ -32,6 +32,7 @@ When a cityName value is set the enclosing element is sent by the Freemarker tem
 |post template to|${GLOBAL_WEATHER_URL}                                                           |
 |check           |response status                        |200                                     |
 |show            |request                                                                         |
+|show            |response headers                                                                |
 |show            |response                                                                        |
 |register prefix |wsX                                    |for namespace|http://www.webserviceX.NET|
 |show            |xPath                                  |!-//wsX:GetWeatherResult/text()-!       |

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/content.txt
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/content.txt
@@ -9,6 +9,7 @@ The >HttpPost2UsingScenarioTest makes multiple SOAP calls to a service, where sc
 >HttpPost3UsingFreemarkerTemplateTest shows the usage of a [[Freemarker][http://freemarker.org]] template to define the content of a SOAP request. This allows for dynamic request structure.
 >JsonHttpTest shows examples with GET, POST, AND PUT, using [[!-JsonPath-!][http://goessner.net/articles/JsonPath/]] to perform checks on the response. 
 >HttpGetFollowRedirectTest shows checking the redirect sent by a server instead of following it.
+>HttpCookieHandling shows how cookie handling can be configured.
 
 !2 Language
 
@@ -39,6 +40,9 @@ The main commands/keywords (i.e. public methods) offered by !-nl.hsac.fitnesse.f
 |response headers                   |HTTP headers received with last response.                                                                                                                             |
 |response header <name>             |Value of HTTP header 'name' in last response received.                                                                                                                |
 |response is valid                  |Whether the last request was successful, or an error.                                                                                                                 |
+|set store cookies <true/false>     |Whether cookies received should be stored (defaults to 'false') and sent with subsequent requests.                                                                    |
+|cookie values                      |Names and values of all cookies stored.                                                                                                                               |
+|cookie value <name>                |Value of stored cookie with name 'name'.                                                                                                                              |
 |set content type <content-type>    |Sets the content type to use when posting.                                                                                                                            |
 
 !3 !-JsonHttpTest-!

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/content.txt
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/content.txt
@@ -47,6 +47,7 @@ The main commands/keywords (i.e. public methods) offered by !-nl.hsac.fitnesse.f
 |cookie <name> path                 |Path of stored cookie with name 'name'.                                                                                                                               |
 |cookie <name> is persistent        |Whether stored cookie with name 'name' is persistent.                                                                                                                 |
 |cookie <name> is secure            |Whether stored cookie with name 'name' requires a secure connection (i.e. should only be sent over secured connections).                                              |
+|cookie <name> attribute <attribute>|Value of attribute 'attribute' of stored cookie with name 'name'.                                                                                                     |
 |clear cookies                      |Clears the stored cookies.                                                                                                                                            |
 |set content type <content-type>    |Sets the content type to use when posting.                                                                                                                            |
 

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/content.txt
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/content.txt
@@ -47,6 +47,7 @@ The main commands/keywords (i.e. public methods) offered by !-nl.hsac.fitnesse.f
 |cookie <name> path                 |Path of stored cookie with name 'name'.                                                                                                                               |
 |cookie <name> is persistent        |Whether stored cookie with name 'name' is persistent.                                                                                                                 |
 |cookie <name> is secure            |Whether stored cookie with name 'name' requires a secure connection (i.e. should only be sent over secured connections).                                              |
+|cookie <name> is http only         |Whether stored cookie with 'name' is http-only (not accessible to Javascript).                                                                                        |
 |cookie <name> attribute <attribute>|Value of attribute 'attribute' of stored cookie with name 'name'.                                                                                                     |
 |clear cookies                      |Clears the stored cookies.                                                                                                                                            |
 |set content type <content-type>    |Sets the content type to use when posting.                                                                                                                            |

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/content.txt
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/content.txt
@@ -40,9 +40,13 @@ The main commands/keywords (i.e. public methods) offered by !-nl.hsac.fitnesse.f
 |response headers                   |HTTP headers received with last response.                                                                                                                             |
 |response header <name>             |Value of HTTP header 'name' in last response received.                                                                                                                |
 |response is valid                  |Whether the last request was successful, or an error.                                                                                                                 |
-|set store cookies <true/false>     |Whether cookies received should be stored (defaults to 'false') and sent with subsequent requests.                                                                    |
+|set store cookies <true/false>     |Whether cookies received, which are not expired, should be stored (defaults to 'false') and sent with subsequent requests.                                            |
 |cookie values                      |Names and values of all cookies stored.                                                                                                                               |
-|cookie value <name>                |Value of stored cookie with name 'name'.                                                                                                                              |
+|cookie <name> value                |Value of stored cookie with name 'name'.                                                                                                                              |
+|cookie <name> domain               |Domain of stored cookie with name 'name'.                                                                                                                             |
+|cookie <name> path                 |Path of stored cookie with name 'name'.                                                                                                                               |
+|cookie <name> is persistent        |Whether stored cookie with name 'name' is persistent.                                                                                                                 |
+|cookie <name> is secure            |Whether stored cookie with name 'name' requires a secure connection (i.e. should only be sent over secured connections).                                              |
 |clear cookies                      |Clears the stored cookies.                                                                                                                                            |
 |set content type <content-type>    |Sets the content type to use when posting.                                                                                                                            |
 

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/content.txt
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/content.txt
@@ -43,6 +43,7 @@ The main commands/keywords (i.e. public methods) offered by !-nl.hsac.fitnesse.f
 |set store cookies <true/false>     |Whether cookies received should be stored (defaults to 'false') and sent with subsequent requests.                                                                    |
 |cookie values                      |Names and values of all cookies stored.                                                                                                                               |
 |cookie value <name>                |Value of stored cookie with name 'name'.                                                                                                                              |
+|clear cookies                      |Clears the stored cookies.                                                                                                                                            |
 |set content type <content-type>    |Sets the content type to use when posting.                                                                                                                            |
 
 !3 !-JsonHttpTest-!


### PR DESCRIPTION
Add ability to check the cookies sent by a server as part of an http response.
Allow a sequence of requests where the cookies received are sent on the next request.