### PR TITLE
Latest apache http client version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,11 +105,15 @@
 			<exclusions>
 				<exclusion>
 					<groupId>org.seleniumhq.selenium</groupId>
-					<artifactId>selenium-htmlunit-driver</artifactId>
+					<artifactId>htmlunit-driver</artifactId>
 				</exclusion>
 				<exclusion>
 					<groupId>cglib</groupId>
 					<artifactId>cglib-nodep</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.httpcomponents</groupId>
+					<artifactId>httpclient</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -69,19 +69,8 @@
 
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpclient</artifactId>
-			<version>4.5.2</version>
-			<exclusions>
-				<exclusion>
-					<groupId>commons-logging</groupId>
-					<artifactId>commons-logging</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpmime</artifactId>
-			<version>4.5.2</version>
+			<version>4.5.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.freemarker</groupId>
@@ -110,10 +99,6 @@
 				<exclusion>
 					<groupId>cglib</groupId>
 					<artifactId>cglib-nodep</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.httpcomponents</groupId>
-					<artifactId>httpclient</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.3.6</version>
+			<version>4.5.2</version>
 			<exclusions>
 				<exclusion>
 					<groupId>commons-logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpmime</artifactId>
-			<version>4.3.6</version>
+			<version>4.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.freemarker</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
 		<fitnesse.version>20160618</fitnesse.version>
 		<selenium.version>2.53.1</selenium.version>
 		<slf4j.version>1.7.21</slf4j.version>
+		<apache.http.version>4.5.2</apache.http.version>
 		<!-- classpath that Fitnesse uses when not starting from IDE/maven -->
 		<standalone.classpath>wiki/fixtures</standalone.classpath>
 		<fitnesse.port>9090</fitnesse.port>
@@ -69,8 +70,19 @@
 
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>${apache.http.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpmime</artifactId>
-			<version>4.5.1</version>
+			<version>${apache.http.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.freemarker</groupId>
@@ -99,6 +111,10 @@
 				<exclusion>
 					<groupId>cglib</groupId>
 					<artifactId>cglib-nodep</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.httpcomponents</groupId>
+					<artifactId>httpclient</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>

--- a/src/main/java/nl/hsac/fitnesse/fixture/Environment.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/Environment.java
@@ -379,6 +379,13 @@ public class Environment {
         httpClient.delete(url, response, headers);
     }
 
+    /**
+     * @return client to use for HTTP calls.
+     */
+    public HttpClient getHttpClient() {
+        return httpClient;
+    }
+
     private void setNamespaceContext(XmlHttpResponse response) {
         response.setNamespaceContext(getNamespaceContext());
     }

--- a/src/main/java/nl/hsac/fitnesse/fixture/Environment.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/Environment.java
@@ -581,11 +581,11 @@ public class Environment {
      * Adds Selenium cookies to response's cookie store.
      * @param response response to which cookies must be added.
      */
-    public void addSeleniumCookies(HttpResponse response, int cookieVersion) {
+    public void addSeleniumCookies(HttpResponse response) {
         CookieStore cookieStore = ensureResponseHasCookieStore(response);
         CookieConverter converter = getCookieConverter();
         Set<Cookie> browserCookies = getSeleniumHelper().getCookies();
-        converter.copySeleniumCookies(browserCookies, cookieStore, cookieVersion);
+        converter.copySeleniumCookies(browserCookies, cookieStore);
     }
 
     protected CookieStore ensureResponseHasCookieStore(HttpResponse response) {

--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/HttpTest.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/HttpTest.java
@@ -476,20 +476,10 @@ public class HttpTest extends SlimFixtureWithMap {
     /**
      * Adds all current Selenium cookies to this fixture's cookie store.
      * This will also ensure this class will store cookies (otherwise copying the cookies has no purpose).
-     * No version attribute will be set on the cookies created (Selenium does not provide the information).
      */
     public void copyBrowserCookies() {
-        copyBrowserCookiesWithVersion(-1);
-    }
-
-    /**
-     * Adds all current Selenium cookies to this fixture's cookie store.
-     * This will also ensure this class will store cookies (otherwise copying the cookies has no purpose).
-     * @param cookieVersion version to set on cookies (Selenium does not provide version information).
-     */
-    public void copyBrowserCookiesWithVersion(int cookieVersion) {
         setStoreCookies(true);
-        getEnvironment().addSeleniumCookies(getResponse(), cookieVersion);
+        getEnvironment().addSeleniumCookies(getResponse());
     }
 
     /**

--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/web/BrowserTest.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/web/BrowserTest.java
@@ -2059,7 +2059,7 @@ public class BrowserTest extends SlimFixture {
      * @param resp response to store content in
      */
     protected void getUrlContent(String url, HttpResponse resp) {
-        getEnvironment().addSeleniumCookies(resp, -1);
+        getEnvironment().addSeleniumCookies(resp);
         getEnvironment().doGet(url, resp);
     }
 

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/HttpClient.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/HttpClient.java
@@ -146,10 +146,10 @@ public class HttpClient {
                 addHeadersToMethod(headers, method);
             }
 
-            CookieStore store = response.getCookieStore();
+            HttpContext context = createContext(response);
 
             startTime = currentTimeMillis();
-            resp = executeMethod(store, method);
+            resp = executeMethod(context, method);
             endTime = currentTimeMillis();
 
             storeResponse(response, resp);
@@ -249,13 +249,18 @@ public class HttpClient {
         return fileName;
     }
 
-    protected org.apache.http.HttpResponse executeMethod(CookieStore store, HttpRequestBase method)
-            throws IOException {
+    protected HttpContext createContext(HttpResponse response) {
         HttpContext localContext = new BasicHttpContext();
+        CookieStore store = response.getCookieStore();
         if (store != null) {
             localContext.setAttribute(HttpClientContext.COOKIE_STORE, store);
         }
-        return httpClient.execute(method, localContext);
+        return localContext;
+    }
+
+    protected org.apache.http.HttpResponse executeMethod(HttpContext context, HttpRequestBase method)
+            throws IOException {
+        return httpClient.execute(method, context);
     }
 
     protected void cleanupAfterRequest(org.apache.http.HttpResponse response, HttpRequestBase method) {

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/HttpClient.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/HttpClient.java
@@ -46,7 +46,6 @@ public class HttpClient {
         DEFAULT_HTTP_CLIENT = HttpClients.custom()
                 .useSystemProperties()
                 .disableContentCompression()
-                .evictExpiredConnections()
                 .setConnectionReuseStrategy(NoConnectionReuseStrategy.INSTANCE)
                 .setUserAgent(HttpClient.class.getName())
                 .setDefaultRequestConfig(rc)

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/HttpClient.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/HttpClient.java
@@ -7,6 +7,7 @@ import org.apache.http.NameValuePair;
 import org.apache.http.client.CookieStore;
 import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
@@ -129,6 +130,7 @@ public class HttpClient {
     protected void getResponse(String url, HttpResponse response, HttpRequestBase method, Map<String, Object> headers) {
         long startTime = 0;
         long endTime = -1;
+        org.apache.http.HttpResponse resp = null;
         try {
             if (headers != null) {
                 for (String key : headers.keySet()) {
@@ -139,7 +141,6 @@ public class HttpClient {
                 }
             }
 
-            org.apache.http.HttpResponse resp;
             CookieStore store = response.getCookieStore();
 
             startTime = currentTimeMillis();
@@ -182,6 +183,13 @@ public class HttpClient {
             }
             response.setResponseTime(endTime - startTime);
             method.reset();
+            if (resp instanceof CloseableHttpResponse) {
+                try {
+                    ((CloseableHttpResponse) resp).close();
+                } catch (IOException e) {
+                    throw new RuntimeException("Unable to close connection", e);
+                }
+            }
         }
     }
 

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/HttpClient.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/HttpClient.java
@@ -17,6 +17,7 @@ import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
+import org.apache.http.impl.NoConnectionReuseStrategy;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.protocol.BasicHttpContext;
@@ -44,6 +45,7 @@ public class HttpClient {
                 .useSystemProperties()
                 .disableContentCompression()
                 .evictExpiredConnections()
+                .setConnectionReuseStrategy(NoConnectionReuseStrategy.INSTANCE)
                 .setUserAgent(HttpClient.class.getName())
                 .setDefaultRequestConfig(rc)
                 .build();

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/HttpClient.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/HttpClient.java
@@ -41,6 +41,7 @@ public class HttpClient {
         HTTP_CLIENT = HttpClients.custom()
                 .useSystemProperties()
                 .disableContentCompression()
+                .evictExpiredConnections()
                 .setUserAgent(HttpClient.class.getName())
                 .setDefaultRequestConfig(rc)
                 .build();

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/HttpClient.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/HttpClient.java
@@ -149,7 +149,7 @@ public class HttpClient {
             CookieStore store = response.getCookieStore();
 
             startTime = currentTimeMillis();
-            resp = executeMethod(url, method, store);
+            resp = executeMethod(store, method);
             endTime = currentTimeMillis();
 
             storeResponse(response, resp);
@@ -249,26 +249,13 @@ public class HttpClient {
         return fileName;
     }
 
-    protected org.apache.http.HttpResponse executeMethod(String url, HttpRequestBase method, CookieStore store)
-            throws IOException {
-        org.apache.http.HttpResponse resp = null;
-        if (store == null) {
-            resp = getHttpResponse(method);
-        } else {
-            resp = getHttpResponse(store, method);
-        }
-        return resp;
-    }
-
-    protected org.apache.http.HttpResponse getHttpResponse(CookieStore store, HttpRequestBase method)
+    protected org.apache.http.HttpResponse executeMethod(CookieStore store, HttpRequestBase method)
             throws IOException {
         HttpContext localContext = new BasicHttpContext();
-        localContext.setAttribute(HttpClientContext.COOKIE_STORE, store);
+        if (store != null) {
+            localContext.setAttribute(HttpClientContext.COOKIE_STORE, store);
+        }
         return httpClient.execute(method, localContext);
-    }
-
-    protected org.apache.http.HttpResponse getHttpResponse(HttpRequestBase method) throws IOException {
-        return httpClient.execute(method);
     }
 
     protected void cleanupAfterRequest(org.apache.http.HttpResponse response, HttpRequestBase method) {

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/HttpClient.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/HttpClient.java
@@ -175,6 +175,29 @@ public class HttpClient {
         }
     }
 
+    protected HttpContext createContext(HttpResponse response) {
+        HttpContext localContext = new BasicHttpContext();
+        CookieStore store = response.getCookieStore();
+        if (store != null) {
+            localContext.setAttribute(HttpClientContext.COOKIE_STORE, store);
+        }
+        return localContext;
+    }
+
+    protected org.apache.http.HttpResponse executeMethod(HttpContext context, HttpRequestBase method)
+            throws IOException {
+        return httpClient.execute(method, context);
+    }
+
+    protected void storeResponse(HttpResponse response, org.apache.http.HttpResponse resp) throws IOException {
+        int returnCode = resp.getStatusLine().getStatusCode();
+        response.setStatusCode(returnCode);
+
+        addHeadersFromResponse(response.getResponseHeaders(), resp.getAllHeaders());
+
+        copyResponseContent(response, resp);
+    }
+
     protected void addHeadersFromResponse(Map<String, Object> responseHeaders, Header[] respHeaders) {
         for (Header h : respHeaders) {
             String headerName = h.getName();
@@ -198,15 +221,6 @@ public class HttpClient {
             valueList.add(headerValue);
             responseHeaders.put(headerName, valueList);
         }
-    }
-
-    protected void storeResponse(HttpResponse response, org.apache.http.HttpResponse resp) throws IOException {
-        int returnCode = resp.getStatusLine().getStatusCode();
-        response.setStatusCode(returnCode);
-
-        addHeadersFromResponse(response.getResponseHeaders(), resp.getAllHeaders());
-
-        copyResponseContent(response, resp);
     }
 
     protected void copyResponseContent(HttpResponse response, org.apache.http.HttpResponse resp) throws IOException {
@@ -247,20 +261,6 @@ public class HttpClient {
             }
         }
         return fileName;
-    }
-
-    protected HttpContext createContext(HttpResponse response) {
-        HttpContext localContext = new BasicHttpContext();
-        CookieStore store = response.getCookieStore();
-        if (store != null) {
-            localContext.setAttribute(HttpClientContext.COOKIE_STORE, store);
-        }
-        return localContext;
-    }
-
-    protected org.apache.http.HttpResponse executeMethod(HttpContext context, HttpRequestBase method)
-            throws IOException {
-        return httpClient.execute(method, context);
     }
 
     protected void cleanupAfterRequest(org.apache.http.HttpResponse response, HttpRequestBase method) {

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/HttpClient.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/HttpClient.java
@@ -17,6 +17,7 @@ import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.protocol.HttpContext;
@@ -32,7 +33,7 @@ import java.util.Map;
  * Helper to make Http calls and get response.
  */
 public class HttpClient {
-    private final static org.apache.http.client.HttpClient HTTP_CLIENT;
+    private final static CloseableHttpClient HTTP_CLIENT;
 
     static {
         RequestConfig rc = RequestConfig.custom()
@@ -130,7 +131,7 @@ public class HttpClient {
     protected void getResponse(String url, HttpResponse response, HttpRequestBase method, Map<String, Object> headers) {
         long startTime = 0;
         long endTime = -1;
-        org.apache.http.HttpResponse resp = null;
+        CloseableHttpResponse resp = null;
         try {
             if (headers != null) {
                 for (String key : headers.keySet()) {
@@ -183,9 +184,9 @@ public class HttpClient {
             }
             response.setResponseTime(endTime - startTime);
             method.reset();
-            if (resp instanceof CloseableHttpResponse) {
+            if (resp != null) {
                 try {
-                    ((CloseableHttpResponse) resp).close();
+                    resp.close();
                 } catch (IOException e) {
                     throw new RuntimeException("Unable to close connection", e);
                 }
@@ -238,13 +239,13 @@ public class HttpClient {
         return fileName;
     }
 
-    protected org.apache.http.HttpResponse getHttpResponse(CookieStore store, String url, HttpRequestBase method) throws IOException {
+    protected CloseableHttpResponse getHttpResponse(CookieStore store, String url, HttpRequestBase method) throws IOException {
         HttpContext localContext = new BasicHttpContext();
         localContext.setAttribute(HttpClientContext.COOKIE_STORE, store);
         return HTTP_CLIENT.execute(method, localContext);
     }
 
-    protected org.apache.http.HttpResponse getHttpResponse(String url, HttpRequestBase method) throws IOException {
+    protected CloseableHttpResponse getHttpResponse(String url, HttpRequestBase method) throws IOException {
         return HTTP_CLIENT.execute(method);
     }
 

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/HttpClient.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/HttpClient.java
@@ -5,6 +5,7 @@ import org.apache.http.HeaderElement;
 import org.apache.http.HttpEntity;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.CookieStore;
+import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
@@ -33,10 +34,15 @@ public class HttpClient {
     private final static org.apache.http.client.HttpClient HTTP_CLIENT;
 
     static {
+        RequestConfig rc = RequestConfig.custom()
+                            .setCookieSpec(CookieSpecs.STANDARD)
+                            .build();
+
         HTTP_CLIENT = HttpClients.custom()
                 .useSystemProperties()
                 .disableContentCompression()
                 .setUserAgent(HttpClient.class.getName())
+                .setDefaultRequestConfig(rc)
                 .build();
     }
 

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/selenium/CookieConverter.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/selenium/CookieConverter.java
@@ -15,12 +15,10 @@ public class CookieConverter {
      * Converts Selenium cookies to Apache http client ones.
      * @param browserCookies cookies in Selenium format.
      * @param cookieStore store to place coverted cookies in.
-     * @param cookieVersion version to use for cookies (Selenium does not provide version information), -1 means set no
-     *                      version.
      */
-    public void copySeleniumCookies(Set<Cookie> browserCookies, CookieStore cookieStore, int cookieVersion) {
+    public void copySeleniumCookies(Set<Cookie> browserCookies, CookieStore cookieStore) {
         for (Cookie browserCookie : browserCookies) {
-            ClientCookie cookie = convertCookie(browserCookie, cookieVersion);
+            ClientCookie cookie = convertCookie(browserCookie);
             cookieStore.addCookie(cookie);
         }
     }
@@ -28,14 +26,10 @@ public class CookieConverter {
     /**
      * Converts Selenium cookie to Apache http client.
      * @param browserCookie selenium cookie.
-     * @param version version of cookie to create (use -1 not to explicitly set value)
      * @return http client format.
      */
-    protected ClientCookie convertCookie(Cookie browserCookie, int version) {
+    protected ClientCookie convertCookie(Cookie browserCookie) {
         BasicClientCookie cookie = new BasicClientCookie(browserCookie.getName(), browserCookie.getValue());
-        if (version > -1) {
-            cookie.setVersion(version);
-        }
         String domain = browserCookie.getDomain();
         if (domain != null && domain.startsWith(".")) {
             // http client does not like domains starting with '.', it always removes it when it receives them

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/BrowserTests/UseCookiesForHttpTest/content.txt
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/BrowserTests/UseCookiesForHttpTest/content.txt
@@ -10,6 +10,7 @@ First http test on its own: 2nd request (with cookies from 1st) gets same cookie
 |check            |response status    |200                |
 |show             |response headers                       |
 |show             |cookie values                          |
+|check not        |cookie value       |uaid    |null      |
 |$uaid1=          |cookie value       |uaid               |
 |note             |see that we get same cookie value again|
 |get from         |${URL_THAT_SENDS_COOKIES}              |

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/BrowserTests/UseCookiesForHttpTest/content.txt
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/BrowserTests/UseCookiesForHttpTest/content.txt
@@ -2,28 +2,47 @@ By taking cookies from a browser's session we can test REST services that are on
 
 Here we don't actually test a login procedure. We just validate cookies are copied and subsequent requests by http test can change the cookies stored.
 
-|script|browser test             |
-|open  |${URL_THAT_SENDS_COOKIES}|
-|$uaid=|cookie value  |uaid      |
-|$ck=  |cookie value  |!-CkTst-! |
-|$pok= |cookie value  |MSPOK     |
-|$requ=|cookie value  |MSPRequ   |
+First http test on its own: 2nd request (with cookies from 1st) gets same cookie value.
+
+|script           |http test                              |
+|set store cookies|true                                   |
+|get from         |${URL_THAT_SENDS_COOKIES}              |
+|check            |response status    |200                |
+|show             |response headers                       |
+|show             |cookie values                          |
+|$uaid1=          |cookie value       |uaid               |
+|note             |see that we get same cookie value again|
+|get from         |${URL_THAT_SENDS_COOKIES}              |
+|check            |response status    |200                |
+|show             |response headers                       |
+|show             |cookie values                          |
+|check            |cookie value       |uaid    |$uaid1    |
+
+Then two requestes one by browser and one by plain http: again same cookie on 2nd request (but not the same as first table).
+
+|script   |browser test                          |
+|open     |${URL_THAT_SENDS_COOKIES}             |
+|$uaid=   |cookie value     |uaid                |
+|note     |see that we get different cookie value|
+|check not|cookie value     |uaid     |$uaid1    |
+|$ck=     |cookie value     |!-CkTst-!           |
+|$pok=    |cookie value     |MSPOK               |
+|$requ=   |cookie value     |MSPRequ             |
+|$loc=    |location                              |
 
 Copying from browser's cookie store implicitly ensures cookies are stored/sent.
 
-|script                           |http test                                                         |
-|note                             |we set version information for cookies (Selenium cannot supply it)|
-|copy browser cookies with version|1                                                                 |
-|check                            |cookie value               |uaid                 |$uaid           |
-|check                            |cookie value               |!-CkTst-!            |$ck             |
-|check                            |cookie value               |MSPOK                |$pok            |
-|check                            |cookie value               |MSPRequ              |$requ           |
-|get from                         |${URL_THAT_SENDS_COOKIES}                                         |
-|check                            |response status            |200                                   |
-|show                             |response headers                                                  |
-|show                             |cookie values                                                     |
-|check not                        |cookie value               |uaid                 |$uaid           |
-|check                            |cookie value               |!-CkTst-!            |$ck             |
-|check                            |cookie value               |MSPOK                |$pok            |
-|check not                        |cookie value               |MSPRequ              |$requ           |
+|script  |http test                                                         |
+|note    |we set version information for cookies (Selenium cannot supply it)|
+|copy browser cookies                                                       |
+|check   |cookie value               |uaid                 |$uaid           |
+|check   |cookie value               |!-CkTst-!            |$ck             |
+|check   |cookie value               |MSPOK                |$pok            |
+|check   |cookie value               |MSPRequ              |$requ           |
+|get from|$loc                                                              |
+|check   |response status            |200                                   |
+|show    |response headers                                                  |
+|show    |cookie values                                                     |
+|note    |see that we get same cookie value as we copied from browser       |
+|check   |cookie value               |uaid                 |$uaid           |
 


### PR DESCRIPTION
- Use latest apache http client
- By default use 'standard' cookie handling
- No longer allow cookie 'version' to be set when copying browser cookies (it shouldn't be needed)
- Make http client configuration easier to change from Java code
- Allow http client usage to be modified more easily by creating subclass
