### PR TITLE
Also save frame's content with 'save page source'

### DIFF
--- a/src/main/java/nl/hsac/fitnesse/fixture/Environment.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/Environment.java
@@ -557,6 +557,41 @@ public class Environment {
     }
 
     /**
+     * Converts a file path into a relative wiki path, if the path is insides the wiki's 'files' section.
+     * @param filePath path to file.
+     * @return relative URL pointing to the file (so a hyperlink to it can be created).
+     */
+    public String getWikiUrl(String filePath) {
+        String wikiUrl = null;
+        String filesDir = getFitNesseFilesSectionDir();
+        if (filePath.startsWith(filesDir)) {
+            String relativeFile = filePath.substring(filesDir.length());
+            relativeFile = relativeFile.replace('\\', '/');
+            wikiUrl = "files" + relativeFile;
+        }
+        return wikiUrl;
+    }
+
+    /**
+     * Gets absolute path from wiki url, if file exists.
+     * @param wikiUrl a relative path that can be used in wiki page, or any file path.
+     * @return absolute path to the target of the url, if such a file exists; null if the target does not exist.
+     */
+    public String getFilePathFromWikiUrl(String wikiUrl) {
+        String url = getHtmlCleaner().getUrl(wikiUrl);
+        File file;
+        if (url.startsWith("files/")) {
+            String relativeFile = url.substring("files".length());
+            relativeFile = relativeFile.replace('/', File.separatorChar);
+            String pathname = getFitNesseFilesSectionDir() + relativeFile;
+            file = new File(pathname);
+        } else {
+            file = new File(url);
+        }
+        return file.exists() ? file.getAbsolutePath() : url;
+    }
+
+    /**
      * @return default (global) map helper.
      */
     public MapHelper getMapHelper() {

--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/SlimFixture.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/SlimFixture.java
@@ -5,7 +5,6 @@ import fitnesse.slim.fixtureInteraction.InteractionAwareFixture;
 import nl.hsac.fitnesse.fixture.Environment;
 import nl.hsac.fitnesse.slim.interaction.ExceptionHelper;
 
-import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 

--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/SlimFixture.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/SlimFixture.java
@@ -116,13 +116,7 @@ public class SlimFixture  implements InteractionAwareFixture {
      * @return relative URL pointing to the file (so a hyperlink to it can be created).
      */
     protected String getWikiUrl(String filePath) {
-        String wikiUrl = null;
-        if (filePath.startsWith(filesDir)) {
-            String relativeFile = filePath.substring(filesDir.length());
-            relativeFile = relativeFile.replace('\\', '/');
-            wikiUrl = "files" + relativeFile;
-        }
-        return wikiUrl;
+        return getEnvironment().getWikiUrl(filePath);
     }
 
     /**
@@ -131,17 +125,7 @@ public class SlimFixture  implements InteractionAwareFixture {
      * @return absolute path to the target of the url, if such a file exists; null if the target does not exist.
      */
     protected String getFilePathFromWikiUrl(String wikiUrl) {
-        String url = getUrl(wikiUrl);
-        File file;
-        if (url.startsWith("files/")) {
-            String relativeFile = url.substring("files".length());
-            relativeFile = relativeFile.replace('/', File.separatorChar);
-            String pathname = filesDir + relativeFile;
-            file = new File(pathname);
-        } else {
-            file = new File(url);
-        }
-        return file.exists() ? file.getAbsolutePath() : url;
+        return getEnvironment().getFilePathFromWikiUrl(wikiUrl);
     }
 
 }

--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/web/BrowserTest.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/web/BrowserTest.java
@@ -1580,10 +1580,10 @@ public class BrowserTest extends SlimFixture {
      */
     public String savePageSource() {
         String fileName = getResourceNameFromLocation();
-        return savePageSourceToLink(fileName, fileName + ".html");
+        return savePageSource(fileName, fileName + ".html");
     }
 
-    protected String savePageSourceToLink(String fileName, String linkText) {
+    protected String savePageSource(String fileName, String linkText) {
         // make href to file
         String url = savePageSourceWithFrames(fileName);
         return String.format("<a href=\"%s\">%s</a>", url, linkText);
@@ -1615,7 +1615,7 @@ public class BrowserTest extends SlimFixture {
             addSourceReplacementsForFrame(sourceReplacements, newLocation, fullUrlOfFrame);
         }
         String html = getCurrentFrameHtml(sourceReplacements);
-        return savePageSource(fileName, html);
+        return saveHtmlAsPageSource(fileName, html);
     }
 
     protected String saveFrameSource(WebElement frame) {
@@ -1670,7 +1670,7 @@ public class BrowserTest extends SlimFixture {
         return path;
     }
 
-    private String savePageSource(String fileName, String html) {
+    protected String saveHtmlAsPageSource(String fileName, String html) {
         String result;
         try {
             String pageSourceName = getPageSourceName(fileName);
@@ -1895,7 +1895,7 @@ public class BrowserTest extends SlimFixture {
                 } else {
                     fileName = "exception";
                 }
-                label = savePageSourceToLink(fileName, label);
+                label = savePageSource(fileName, label);
             } catch (UnhandledAlertException e) {
                 // https://code.google.com/p/selenium/issues/detail?id=4412
                 System.err.println("Unable to capture page source while alert is present for exception: " + messageBase);

--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/web/BrowserTest.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/web/BrowserTest.java
@@ -1624,6 +1624,10 @@ public class BrowserTest extends SlimFixture {
                     String newLocation = savePageSourceWithFrames();
                     nestedPages.put(fullUrlOfFrame, newLocation);
                     nestedPages.put(relativeUrlOfFrame, newLocation);
+                    String framePath = getPath(fullUrlOfFrame);
+                    if (framePath != null) {
+                        nestedPages.put(framePath, newLocation);
+                    }
                 } finally {
                     getSeleniumHelper().switchToParentFrame();
                 }
@@ -1651,6 +1655,17 @@ public class BrowserTest extends SlimFixture {
         }
 
         return result;
+    }
+
+    protected String getPath(String urlString) {
+        String path = null;
+        try {
+            URL url = new URL(urlString);
+            path = url.getPath();
+        } catch (MalformedURLException e) {
+            // leave path null
+        }
+        return path;
     }
 
     protected String savePageSourceWithFormat(String fileName, String linkFormat) {

--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/web/BrowserTest.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/web/BrowserTest.java
@@ -1579,8 +1579,8 @@ public class BrowserTest extends SlimFixture {
      * @return hyperlink to the file containing the page source.
      */
     public String savePageSource() {
-        String url = savePageSourceWithFrames();
         String fileName = getResourceNameFromLocation();
+        String url = savePageSourceWithFrames(fileName);
         return String.format("<a href=\"%s\">%s.html</a>", url, fileName);
     }
 
@@ -1605,9 +1605,8 @@ public class BrowserTest extends SlimFixture {
         return savePageSourceWithFormat(fileName, "<a href=\"%s\">"+ linkText + "</a>");
     }
 
-    public String savePageSourceWithFrames() {
+    protected String savePageSourceWithFrames(String fileName) {
         String result = null;
-        String fileName = getResourceNameFromLocation();
         List<WebElement> frames = findAllByCss("iframe,frame");
         if (frames.isEmpty()) {
             result = savePageSourceWithFormat(fileName, "%s");
@@ -1635,6 +1634,16 @@ public class BrowserTest extends SlimFixture {
         }
 
         return result;
+    }
+
+    protected String saveFrameSource(WebElement frame) {
+        try {
+            getSeleniumHelper().switchToFrame(frame);
+            String fileName = getResourceNameFromLocation();
+            return savePageSourceWithFrames(fileName);
+        } finally {
+            getSeleniumHelper().switchToParentFrame();
+        }
     }
 
     protected String getCurrentFrameHtml(Map<String, String> sourceReplacements) {
@@ -1665,15 +1674,6 @@ public class BrowserTest extends SlimFixture {
         String framePath = getPath(fullUrlOfFrame);
         if (framePath != null) {
             sourceReplacements.put(framePath, savedLocation);
-        }
-    }
-
-    protected String saveFrameSource(WebElement frame) {
-        try {
-            getSeleniumHelper().switchToFrame(frame);
-            return savePageSourceWithFrames();
-        } finally {
-            getSeleniumHelper().switchToParentFrame();
         }
     }
 

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/selenium/PageSourceSaver.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/selenium/PageSourceSaver.java
@@ -1,0 +1,152 @@
+package nl.hsac.fitnesse.fixture.util.selenium;
+
+import nl.hsac.fitnesse.fixture.Environment;
+import nl.hsac.fitnesse.fixture.util.FileUtil;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Saves page source to disk.
+ */
+public class PageSourceSaver {
+    private static final By SELECTOR = By.cssSelector("iframe,frame");
+    private final String pageSourceBase;
+    private final Environment environment = Environment.getInstance();
+    private final SeleniumHelper helper;
+
+    /**
+     * Creates new.
+     * @param pageSourceBase directory where pages will be saved.
+     * @param helper helper to interact with Selenium.
+     */
+    public PageSourceSaver(String pageSourceBase, SeleniumHelper helper) {
+        this.pageSourceBase = pageSourceBase;
+        this.helper = helper;
+    }
+
+    /**
+     * Saves current page's source, as new file.
+     * @param fileName filename to use for saved page.
+     * @return wiki Url, if file was created inside wiki's files dir, absolute filename otherwise.
+     */
+    public String savePageSource(String fileName) {
+        Map<String, String> sourceReplacements = new HashMap<>();
+        List<WebElement> frames = getFrames();
+        for (WebElement frame : frames) {
+            String newLocation = saveFrameSource(frame);
+            String fullUrlOfFrame = frame.getAttribute("src");
+
+            addSourceReplacementsForFrame(sourceReplacements, newLocation, fullUrlOfFrame);
+        }
+        String html = getCurrentFrameHtml(sourceReplacements);
+        return saveHtmlAsPageSource(fileName, html);
+    }
+
+    protected String saveFrameSource(WebElement frame) {
+        try {
+            getSeleniumHelper().switchToFrame(frame);
+            String fileName = getSeleniumHelper().getResourceNameFromLocation();
+            return savePageSource(fileName);
+        } finally {
+            getSeleniumHelper().switchToParentFrame();
+        }
+    }
+
+    protected String getCurrentFrameHtml(Map<String, String> sourceReplacements) {
+        String html = getSeleniumHelper().getHtml();
+        if (sourceReplacements != null && !sourceReplacements.isEmpty()) {
+            html = replaceSourceOfFrames(sourceReplacements, html);
+        }
+        return html;
+    }
+
+    protected String replaceSourceOfFrames(Map<String, String> sourceReplacements, String html) {
+        for (Map.Entry<String, String> entry : sourceReplacements.entrySet()) {
+            String originalLocation = entry.getKey();
+            String newLocation = entry.getValue();
+            html = html.replace("src=\"" + originalLocation + "\"", "src=\"/" + newLocation + "\"");
+        }
+        return html;
+    }
+
+    protected void addSourceReplacementsForFrame(Map<String, String> sourceReplacements, String savedLocation, String fullUrlOfFrame) {
+        String fullUrlOfParent = getLocation();
+        int lastSlash = fullUrlOfParent.lastIndexOf("/");
+        String baseUrl = fullUrlOfParent.substring(0, lastSlash + 1);
+        String relativeUrlOfFrame = fullUrlOfFrame.replace(baseUrl, "");
+
+        sourceReplacements.put(fullUrlOfFrame, savedLocation);
+        sourceReplacements.put(relativeUrlOfFrame, savedLocation);
+        String framePath = getPath(fullUrlOfFrame);
+        if (framePath != null) {
+            sourceReplacements.put(framePath, savedLocation);
+        }
+    }
+
+    protected String getPath(String urlString) {
+        String path = null;
+        try {
+            URL url = new URL(urlString);
+            path = url.getPath();
+        } catch (MalformedURLException e) {
+            // leave path null
+        }
+        return path;
+    }
+
+
+    protected String saveHtmlAsPageSource(String fileName, String html) {
+        String result;
+        try {
+            String pageSourceName = getPageSourceName(fileName);
+            String file = FileUtil.saveToFile(pageSourceName, "html", html.getBytes("utf-8"));
+            String wikiUrl = getWikiUrl(file);
+            if (wikiUrl != null) {
+                result = wikiUrl;
+            } else {
+                result = file;
+            }
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException("Unable to save source", e);
+        }
+        return result;
+    }
+
+    /**
+     * Converts a file path into a relative wiki path, if the path is insides the wiki's 'files' section.
+     * @param filePath path to file.
+     * @return relative URL pointing to the file (so a hyperlink to it can be created).
+     */
+    protected String getWikiUrl(String filePath) {
+        return environment.getWikiUrl(filePath);
+    }
+
+    protected List<WebElement> getFrames() {
+        return getDriver().findElements(SELECTOR);
+    }
+
+    protected String getLocation() {
+        return getDriver().getCurrentUrl();
+    }
+
+    protected WebDriver getDriver() {
+        return getSeleniumHelper().driver();
+    }
+
+
+    protected String getPageSourceName(String fileName) {
+        return pageSourceBase + fileName;
+    }
+
+    protected SeleniumHelper getSeleniumHelper() {
+        return helper;
+    }
+}

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/selenium/SeleniumHelper.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/selenium/SeleniumHelper.java
@@ -2,6 +2,7 @@ package nl.hsac.fitnesse.fixture.util.selenium;
 
 import nl.hsac.fitnesse.fixture.slim.StopTestException;
 import nl.hsac.fitnesse.fixture.util.FileUtil;
+import org.apache.commons.io.FilenameUtils;
 import org.openqa.selenium.*;
 import org.openqa.selenium.ie.InternetExplorerDriver;
 import org.openqa.selenium.interactions.Actions;
@@ -14,6 +15,8 @@ import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.FluentWait;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -1124,6 +1127,22 @@ public class SeleniumHelper {
         return FileUtil.saveToFile(baseName, "png", png);
     }
 
+    public String getResourceNameFromLocation() {
+        String fileName = "pageSource";
+        try {
+            String location = driver().getCurrentUrl();
+            URL u = new URL(location);
+            String file = FilenameUtils.getName(u.getPath());
+            file = file.replaceAll("^(.*?)(\\.html?)?$", "$1");
+            if (!"".equals(file)) {
+                fileName = file;
+            }
+        } catch (MalformedURLException e) {
+            // ignore
+        }
+        return fileName;
+    }
+
     /**
      * @return HTML content of current page.
      */
@@ -1156,6 +1175,10 @@ public class SeleniumHelper {
             }
         }
         return html;
+    }
+
+    public PageSourceSaver getPageSourceSaver(String baseDir) {
+        return new PageSourceSaver(baseDir, this);
     }
 
     /**

--- a/wiki/FitNesseRoot/HsacAcceptanceTests/SlimTests/BrowserTest/FrameHandlingTests/FrameHandling/content.txt
+++ b/wiki/FitNesseRoot/HsacAcceptanceTests/SlimTests/BrowserTest/FrameHandlingTests/FrameHandling/content.txt
@@ -67,6 +67,7 @@ This test ensures we can find elements inside frames.
 |script                        |browser test                                |
 |open                          |$url/main                                   |
 |seconds before timeout        |1                                           |
+|show                          |save page source                            |
 |check                         |value of          |Add button2|Add2         |
 |check                         |value of          |Add button3|Add3         |
 |check                         |value of          |Add button4|Add4         |

--- a/wiki/FitNesseRoot/HsacAcceptanceTests/SlimTests/BrowserTest/FrameHandlingTests/IframeHandling/content.txt
+++ b/wiki/FitNesseRoot/HsacAcceptanceTests/SlimTests/BrowserTest/FrameHandlingTests/IframeHandling/content.txt
@@ -81,6 +81,7 @@ This test ensures we can find elements inside iframes.
 |open                  |$url/main                                     |
 |seconds before timeout|1                                             |
 |check                 |page title        |Start Page Title           |
+|show                  |save page source                              |
 |check                 |value of          |Add button |Add            |
 |check                 |value of          |Add button1|Add1           |
 |check                 |value of          |Add button2|Add2           |


### PR DESCRIPTION
Previously the file created by 'save page source' (and the page content captured on exception) in BrowserTest only captured the content of the top-level page (e.g. the 'default content').

With this pull requests we also capture the content of any (i)frames the page may contain.