### PR TITLE
Stringfixture valueOF and BrowserTest valueOf have same name

### DIFF
--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/StringFixture.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/StringFixture.java
@@ -18,6 +18,15 @@ public class StringFixture extends SlimFixture {
     public String valueOf(String value) {
         return value;
     }
+	
+	/**
+     * Returns value.
+     * @param value value to return
+     * @return value
+     */
+    public String assignTo(String value) {
+        return value;
+    }
 
     /**
      * Determines length of string.


### PR DESCRIPTION
Reason:
I use StringFixture and BrowserTest in combination 
```
|library|
|string fixture|
|browser test|
```
If i wanna use StringFixtures value of, i would need to change too string fixture and after that back too browser test

Propossal:
Introduce same function of valueOf under a different name, as I did in this pull request 
(this allows you to access StringFixtures valueOf by using assignTo)
Idealy would be to @Deprecated valueOf in StringFixture. but I left that open since that might have a major impact
