### PR TITLE
Added support for filtering suites by in- and excluding tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The result in JUnit XML results can be found in: `target/failsafe-reports` (most
 The HTML results can be found in: `target/fitnesse-results/index.html`
 
 The FitNesse suite to run can be specified by changing the value of the `@Suite` annotation in `nl.hsac.fitnesse.fixture.FixtureDebugTest`, or (preferably) by adding a system property, called `fitnesseSuiteToRun`, specifying the suite to run to the build server's mvn execution.
+By using the `@SuiteFilter` and `@ExcludeSuiteFilter` annotations, or (preferably) by adding `suiteFilter` and/or `excludeSuiteFilter` system properties, one can provide tags to in- or exclude and further filter the tests to run within the specified suite. Provide multiple tags by comma-separating them.
 
 The Selenium configuration (e.g. what browser on what platform) to use when testing websites can be overridden by using system properties (i.e. `seleniumGridUrl` and either `seleniumBrowser` or `seleniumCapabilities`).
 This allows different configurations on the build server to test with different browsers, without requiring different Wiki content, but only requiring a different build configuration.

--- a/src/main/java/nl/hsac/fitnesse/junit/HsacFitNesseRunner.java
+++ b/src/main/java/nl/hsac/fitnesse/junit/HsacFitNesseRunner.java
@@ -146,12 +146,10 @@ public class HsacFitNesseRunner extends FitNesseRunner {
     @Override
     protected boolean getSuiteFilterAndStrategy(Class<?> klass) throws Exception {
         String strategy = System.getProperty(SUITE_FILTER_STRATEGY_OVERRIDE_VARIABLE_NAME);
-        if(StringUtils.isEmpty(strategy)){
+        if (StringUtils.isEmpty(strategy)) {
             return super.getSuiteFilterAndStrategy(klass);
-        } else if (strategy.equalsIgnoreCase("and")){
-            return true;
         } else {
-            return false;
+            return strategy.equalsIgnoreCase("and");
         }
     }
 
@@ -160,10 +158,7 @@ public class HsacFitNesseRunner extends FitNesseRunner {
         String suiteFilter = System.getProperty(SUITE_FILTER_OVERRIDE_VARIABLE_NAME);
         if (StringUtils.isEmpty(suiteFilter)) {
             SuiteFilter suiteFilterAnnotation = klass.getAnnotation(SuiteFilter.class);
-            if (suiteFilterAnnotation == null) {
-                return null;
-            }
-            suiteFilter = suiteFilterAnnotation.value();
+            return suiteFilterAnnotation == null?null:suiteFilterAnnotation.value();
         }
         return suiteFilter;
     }
@@ -172,11 +167,7 @@ public class HsacFitNesseRunner extends FitNesseRunner {
     protected String getExcludeSuiteFilter(Class<?> klass) throws Exception {
         String excludeSuiteFilter = System.getProperty(EXCLUDE_SUITE_FILTER_OVERRIDE_VARIABLE_NAME);
         if (StringUtils.isEmpty(excludeSuiteFilter)) {
-            ExcludeSuiteFilter excludeSuiteFilterAnnotation = klass.getAnnotation(ExcludeSuiteFilter.class);
-            if (excludeSuiteFilterAnnotation == null) {
-                return null;
-            }
-            excludeSuiteFilter = excludeSuiteFilterAnnotation.value();
+            return super.getExcludeSuiteFilter(klass);
         }
         return excludeSuiteFilter;
     }

--- a/src/main/java/nl/hsac/fitnesse/junit/HsacFitNesseRunner.java
+++ b/src/main/java/nl/hsac/fitnesse/junit/HsacFitNesseRunner.java
@@ -21,6 +21,10 @@ import org.junit.runners.model.InitializationError;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -134,6 +138,33 @@ public class HsacFitNesseRunner extends FitNesseRunner {
             }
         }
 
+    }
+
+    // In the original runner class, we cannot use a system property as annotation value,
+    // so we override it to work exactly like the suiteFilter annotation.
+    // This also needs the ExcludeSuiteFilter interface
+    @Override
+    protected String getExcludeSuiteFilter(Class<?> klass) throws Exception {
+        ExcludeSuiteFilter excludeSuiteFilterAnnotation = (ExcludeSuiteFilter)klass.getAnnotation(ExcludeSuiteFilter.class);
+        if (excludeSuiteFilterAnnotation == null) {
+            return null;
+        } else if (!"".equals(excludeSuiteFilterAnnotation.value())) {
+            return excludeSuiteFilterAnnotation.value();
+        } else if (!"".equals(excludeSuiteFilterAnnotation.systemProperty())) {
+            return System.getProperty(excludeSuiteFilterAnnotation.systemProperty());
+        } else {
+            throw new InitializationError("In annotation @ExcludeSuiteFilter you have to specify either \'value\' or \'systemProperty\'");
+        }
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.TYPE})
+    public @interface ExcludeSuiteFilter {
+        String value() default "";
+
+        String systemProperty() default "";
+
+        boolean andStrategy() default false;
     }
 
     /**

--- a/src/test/java/nl/hsac/fitnesse/fixture/FixtureDebugTest.java
+++ b/src/test/java/nl/hsac/fitnesse/fixture/FixtureDebugTest.java
@@ -8,8 +8,8 @@ import org.junit.runner.RunWith;
  * Test class to allow fixture code to be debugged.
  */
 @RunWith(HsacFitNesseRunner.class)
-@FitNesseRunner.SuiteFilter(systemProperty = "suiteFilter")
-@HsacFitNesseRunner.ExcludeSuiteFilter(systemProperty = "excludeSuiteFilter")
-@FitNesseRunner.Suite(systemProperty = "fitnesseSuiteToRun")
+@FitNesseRunner.SuiteFilter()
+@HsacFitNesseRunner.ExcludeSuiteFilter()
+@FitNesseRunner.Suite()
 public class FixtureDebugTest {
 }

--- a/src/test/java/nl/hsac/fitnesse/fixture/FixtureDebugTest.java
+++ b/src/test/java/nl/hsac/fitnesse/fixture/FixtureDebugTest.java
@@ -8,6 +8,8 @@ import org.junit.runner.RunWith;
  * Test class to allow fixture code to be debugged.
  */
 @RunWith(HsacFitNesseRunner.class)
-@FitNesseRunner.Suite("HsacAcceptanceTests.SlimTests.HttpTest.XmlHttpTest")
+@FitNesseRunner.SuiteFilter(systemProperty = "suiteFilter")
+@HsacFitNesseRunner.ExcludeSuiteFilter(systemProperty = "excludeSuiteFilter")
+@FitNesseRunner.Suite(systemProperty = "fitnesseSuiteToRun")
 public class FixtureDebugTest {
 }

--- a/wiki/FitNesseRoot/HsacExamples/TaggedTestcases.wiki
+++ b/wiki/FitNesseRoot/HsacExamples/TaggedTestcases.wiki
@@ -5,17 +5,21 @@ Suite
 
 Running this suite using: 
  * mvn test-compile failsafe:integration-test -DfitnesseSuiteToRun=HsacExamples.TaggedTestcases -DsuiteFilter=runMe -DexcludeSuiteFilter=dontRun
-  * Results in 3 test cases 001, 002 to be executed (all cases that have the tag 'runMe', and don't have the tag 'dontRun')
+  * Results in 3 test cases: 001, 002 to be executed (all cases that have the tag 'runMe', and don't have the tag 'dontRun')
  * mvn test-compile failsafe:integration-test -DfitnesseSuiteToRun=HsacExamples.TaggedTestcases -DexcludeSuiteFilter=runMe
-  * Results in 3 test cases 003, 004, 006 to be executed (all cases that don't have the tag 'runMe') 
+  * Results in 3 test cases: 003, 004, 006 to be executed (all cases that don't have the tag 'runMe') 
  * mvn test-compile failsafe:integration-test -DfitnesseSuiteToRun=HsacExamples.TaggedTestcases -DsuiteFilter=runMe
-  * Results in 3 test cases 001, 002, 005 to be executed (all cases that do have the tag 'runMe')
+  * Results in 3 test cases: 001, 002, 005 to be executed (all cases that do have the tag 'runMe')
   
-Passing a comma separated list to the (exlude)suiteFilter is allowed, so we can also use:
- * mvn test-compile failsafe:integration-test -DfitnesseSuiteToRun=HsacExamples.TaggedTestcases -DsuiteFilter=run,dontRun
-  * Results in 5 test cases 001, 002, 003, 004, 005 to be executed (all cases that have the tag 'runMe' OR 'dontRun')
+Passing a comma separated list to the (exlude)suiteFilter is allowed. 
+The suiteFilter can be used as AND or as OR filter by setting the suiteFilterStrategy parameter to 'and' (case-insensitive). Default behaviour is OR. The excludeSuiteFilter always behaves as an OR filter.
+So we can also use:
+ * mvn test-compile failsafe:integration-test -DfitnesseSuiteToRun=HsacExamples.TaggedTestcases -DsuiteFilter=runMe,dontRun
+  * Results in 5 test cases: 001, 002, 003, 004, 005 to be executed (all cases that have the tag 'runMe' OR 'dontRun')
+ * mvn test-compile failsafe:integration-test -DfitnesseSuiteToRun=HsacExamples.TaggedTestcases -DsuiteFilter=runMe,dontRun -DsuiteFilterStrategy=and
+  * Results in 1 test case: 005 to be executed (all cases that have the tag 'runMe' AND 'dontRun') 
  * mvn test-compile failsafe:integration-test -DfitnesseSuiteToRun=HsacExamples.TaggedTestcases -DexcludeSuiteFilter=runMe,dontRun
-  * Results in 1 test case 006 to be executed (all cases that don't have the tag 'runMe' OR 'dontRun')
+  * Results in 1 test case: 006 to be executed (all cases that don't have the tag 'runMe' OR 'dontRun')
   
 
 !contents -R2 -g -p -f -h

--- a/wiki/FitNesseRoot/HsacExamples/TaggedTestcases.wiki
+++ b/wiki/FitNesseRoot/HsacExamples/TaggedTestcases.wiki
@@ -12,7 +12,7 @@ Running this suite using:
   * Results in 3 test cases: 001, 002, 005 to be executed (all cases that do have the tag 'runMe')
   
 Passing a comma separated list to the (exlude)suiteFilter is allowed. 
-The suiteFilter can be used as AND or as OR filter by setting the suiteFilterStrategy parameter to 'and' (case-insensitive). Default behaviour is OR. The excludeSuiteFilter always behaves as an OR filter.
+The suiteFilter can be used as AND or as OR filter by setting the suiteFilterStrategy system property to 'and' (case-insensitive). Default behaviour is OR. The excludeSuiteFilter always behaves as an OR filter.
 So we can also use:
  * mvn test-compile failsafe:integration-test -DfitnesseSuiteToRun=HsacExamples.TaggedTestcases -DsuiteFilter=runMe,dontRun
   * Results in 5 test cases: 001, 002, 003, 004, 005 to be executed (all cases that have the tag 'runMe' OR 'dontRun')

--- a/wiki/FitNesseRoot/HsacExamples/TaggedTestcases.wiki
+++ b/wiki/FitNesseRoot/HsacExamples/TaggedTestcases.wiki
@@ -1,0 +1,23 @@
+---
+Suite
+---
+!1 Suite To test running a filtered suite from maven
+
+Running this suite using: 
+ * mvn test-compile failsafe:integration-test -DfitnesseSuiteToRun=HsacExamples.TaggedTestcases -DsuiteFilter=runMe -DexcludeSuiteFilter=dontRun
+  * Results in 3 test cases 001, 002 to be executed (all cases that have the tag 'runMe', and don't have the tag 'dontRun')
+ * mvn test-compile failsafe:integration-test -DfitnesseSuiteToRun=HsacExamples.TaggedTestcases -DexcludeSuiteFilter=runMe
+  * Results in 3 test cases 003, 004, 006 to be executed (all cases that don't have the tag 'runMe') 
+ * mvn test-compile failsafe:integration-test -DfitnesseSuiteToRun=HsacExamples.TaggedTestcases -DsuiteFilter=runMe
+  * Results in 3 test cases 001, 002, 005 to be executed (all cases that do have the tag 'runMe')
+  
+Passing a comma separated list to the (exlude)suiteFilter is allowed, so we can also use:
+ * mvn test-compile failsafe:integration-test -DfitnesseSuiteToRun=HsacExamples.TaggedTestcases -DsuiteFilter=run,dontRun
+  * Results in 5 test cases 001, 002, 003, 004, 005 to be executed (all cases that have the tag 'runMe' OR 'dontRun')
+ * mvn test-compile failsafe:integration-test -DfitnesseSuiteToRun=HsacExamples.TaggedTestcases -DexcludeSuiteFilter=runMe,dontRun
+  * Results in 1 test case 006 to be executed (all cases that don't have the tag 'runMe' OR 'dontRun')
+  
+
+!contents -R2 -g -p -f -h
+
+!define TEST_SYSTEM {slim}

--- a/wiki/FitNesseRoot/HsacExamples/TaggedTestcases/SuiteSetUp.wiki
+++ b/wiki/FitNesseRoot/HsacExamples/TaggedTestcases/SuiteSetUp.wiki
@@ -1,0 +1,9 @@
+---
+Suite
+---
+!1 Test suite X
+!contents -R2 -g -p -f -h
+
+|Import                           |
+|nl.hsac.fitnesse.fixture         |
+|nl.hsac.fitnesse.fixture.slim    |

--- a/wiki/FitNesseRoot/HsacExamples/TaggedTestcases/T001.wiki
+++ b/wiki/FitNesseRoot/HsacExamples/TaggedTestcases/T001.wiki
@@ -1,0 +1,7 @@
+---
+Suites: runMe
+Test
+---
+!note This test intentionally does nothing and is used to test suite filtering
+|script|string fixture|
+|check |value of  | | |

--- a/wiki/FitNesseRoot/HsacExamples/TaggedTestcases/T002.wiki
+++ b/wiki/FitNesseRoot/HsacExamples/TaggedTestcases/T002.wiki
@@ -1,0 +1,7 @@
+---
+Suites: runMe
+Test
+---
+!note This test intentionally does nothing and is used to test suite filtering
+|script|string fixture|
+|check |value of  | | |

--- a/wiki/FitNesseRoot/HsacExamples/TaggedTestcases/T003.wiki
+++ b/wiki/FitNesseRoot/HsacExamples/TaggedTestcases/T003.wiki
@@ -1,0 +1,7 @@
+---
+Suites: dontRun
+Test
+---
+!note This test intentionally does nothing and is used to test suite filtering
+|script|string fixture|
+|check |value of  | | |

--- a/wiki/FitNesseRoot/HsacExamples/TaggedTestcases/T004.wiki
+++ b/wiki/FitNesseRoot/HsacExamples/TaggedTestcases/T004.wiki
@@ -1,0 +1,7 @@
+---
+Suites: dontRun
+Test
+---
+!note This test intentionally does nothing and is used to test suite filtering
+|script|string fixture|
+|check |value of  | | |

--- a/wiki/FitNesseRoot/HsacExamples/TaggedTestcases/T005.wiki
+++ b/wiki/FitNesseRoot/HsacExamples/TaggedTestcases/T005.wiki
@@ -1,0 +1,7 @@
+---
+Suites: runMe, dontRun
+Test
+---
+!note This test intentionally does nothing and is used to test suite filtering
+|script|string fixture|
+|check |value of  | | |

--- a/wiki/FitNesseRoot/HsacExamples/TaggedTestcases/T006NoTags.wiki
+++ b/wiki/FitNesseRoot/HsacExamples/TaggedTestcases/T006NoTags.wiki
@@ -1,0 +1,6 @@
+---
+Test
+---
+!note This test intentionally does nothing and is used to test suite filtering
+|script|string fixture|
+|check |value of  | | |


### PR DESCRIPTION
Added possibility to in- and exclude tags from a command-line run.
This can be done by specifying the SuiteFilter and ExcludeSuiteFilter annotations on FixtureDebugTest, or by specifying system properties 'suiteFilter' and/or 'excludeSuiteFilter'.

The ExcludeSuiteFilter interface and getExcludeSuiteFilter method for excluding tags could also be implemented fitnesse-side IMO. They are in HsacFitnesseRunner now, so that we can use a system property.

I have kept the syntax exactly as it is in FitNesseRunner for the SuiteFilter (that one does accept a sysprop value as it is in FitNesse)

An example suite with tagged tests is provided in HsacExamples.TaggedTestcases
