### PR TITLE
A new test to test JSON and arrays

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,13 @@
 			<version>4.12</version>
 			<scope>provided</scope>
 		</dependency>
+		<!--  Gson: Java to Json conversion -->
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.7</version>
+			<scope>compile</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -170,13 +170,6 @@
 			<version>4.12</version>
 			<scope>provided</scope>
 		</dependency>
-		<!--  Gson: Java to Json conversion -->
-		<dependency>
-			<groupId>com.google.code.gson</groupId>
-			<artifactId>gson</artifactId>
-			<version>2.7</version>
-			<scope>compile</scope>
-		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/JsonHelper.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/JsonHelper.java
@@ -1,5 +1,9 @@
 package nl.hsac.fitnesse.fixture.util;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonParseException;
+import java.util.HashMap;
+
 import net.minidev.json.JSONArray;
 import nl.hsac.fitnesse.fixture.Environment;
 import org.apache.commons.lang3.StringUtils;
@@ -39,11 +43,11 @@ public class JsonHelper implements Formatter {
         if (StringUtils.isEmpty(jsonString)) {
             return null;
         }
-        JSONObject jsonObject;
         try {
-            jsonObject = new JSONObject(jsonString);
-            return jsonObjectToMap(jsonObject);
-        } catch (JSONException e) {
+            Map<String, Object> result = new HashMap<String, Object>();
+            result = (Map<String, Object>)new Gson().fromJson(jsonString, result.getClass());
+            return result;
+        } catch (JsonParseException e) {
             throw new RuntimeException("Unable to convert string to map: " + jsonString, e);
         }
     }

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/JsonHelper.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/JsonHelper.java
@@ -44,7 +44,7 @@ public class JsonHelper implements Formatter {
             return null;
         }
         try {
-            Map<String, Object> result = new HashMap<String, Object>();
+            Map<String, Object> result = new HashMap<>();
             result = (Map<String, Object>)new Gson().fromJson(jsonString, result.getClass());
             return result;
         } catch (JsonParseException e) {

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/JsonHelper.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/JsonHelper.java
@@ -44,9 +44,7 @@ public class JsonHelper implements Formatter {
             return null;
         }
         try {
-            Map<String, Object> result = new HashMap<>();
-            result = (Map<String, Object>)new Gson().fromJson(jsonString, result.getClass());
-            return result;
+            return new Gson().fromJson(jsonString, HashMap.class);
         } catch (JsonParseException e) {
             throw new RuntimeException("Unable to convert string to map: " + jsonString, e);
         }

--- a/src/main/java/nl/hsac/fitnesse/junit/selenium/SeleniumJsonGridDriverFactoryFactory.java
+++ b/src/main/java/nl/hsac/fitnesse/junit/selenium/SeleniumJsonGridDriverFactoryFactory.java
@@ -1,6 +1,5 @@
 package nl.hsac.fitnesse.junit.selenium;
 
-import com.google.gson.Gson;
 import nl.hsac.fitnesse.fixture.slim.web.SeleniumDriverSetup;
 import nl.hsac.fitnesse.fixture.util.selenium.SeleniumHelper;
 import nl.hsac.fitnesse.fixture.Environment;

--- a/src/test/java/nl/hsac/fitnesse/fixture/util/JsonHelperTest.java
+++ b/src/test/java/nl/hsac/fitnesse/fixture/util/JsonHelperTest.java
@@ -123,7 +123,7 @@ public class JsonHelperTest {
 
     @Test
     public void testListedMap() {
-        ArrayList<Object> listargs = new ArrayList<Object>();
+        ArrayList<Object> listargs = new ArrayList<>();
         listargs.add("start-maximized");
 
         Map<String, Object> chromeOptions = new LinkedHashMap<>();

--- a/src/test/java/nl/hsac/fitnesse/fixture/util/JsonHelperTest.java
+++ b/src/test/java/nl/hsac/fitnesse/fixture/util/JsonHelperTest.java
@@ -2,6 +2,7 @@ package nl.hsac.fitnesse.fixture.util;
 
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -118,5 +119,21 @@ public class JsonHelperTest {
 
         assertEquals(expected,
                 helper.jsonStringToMap("{\"browserName\":\"chrome\",\"chromeOptions\":{\"mobileEmulation\":{\"deviceName\":\"Google Nexus 5\"}}}"));
+    }
+
+    @Test
+    public void testListedMap() {
+        ArrayList<Object> listargs = new ArrayList<Object>();
+        listargs.add("start-maximized");
+
+        Map<String, Object> chromeOptions = new LinkedHashMap<>();
+        chromeOptions.put("args", listargs);
+
+        Map<String, Object> expected = new LinkedHashMap<>();
+        expected.put("browserName", "chrome");
+        expected.put("chromeOptions", chromeOptions);
+
+        assertEquals(expected,
+                helper.jsonStringToMap("{\"browserName\":\"chrome\",\"chromeOptions\":{\"args\":[\"start-maximized\"]}}"));
     }
 }


### PR DESCRIPTION
We would like to start chrome with args/extenions; both expect a list of strings
This works:
```
|script|list fixture   |
|add   |start-maximized|
|$args=|copy list      |

|script         |map fixture   |
|set value      |$args|for|args|
|$chromeoptions=|copy map      |

|script          |selenium driver setup             |
|start driver for|chrome|with profile|$chromeoptions|
|show            |driver description                |
```

but it does not work using json ```
-DseleniumJsonCapabilities="{\"browserName\":\"chrome\", \"chromeOptions\":{\"args\":[\"start-maximized\"]}}"```

Tried it with the use of Gson then it works fine; (included in this pull request)
Maby you can fix your parser for the new test so gson isn't needed

```