### PR TITLE
Use phantomjs 2.1.1 on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: java
 jdk:
   - oraclejdk8
 
+dist: trusty
+sudo: false
+
 matrix:
   fast_finish: true
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
   - "phantomjs --version"
 
 script:
-  - ./travis_build_and_test.sh
+  - travis_wait 60 ./travis_build_and_test.sh
 
 after_success:
   - "[[ \"${TRAVIS_PULL_REQUEST}\" == \"false\" && \"${TRAVIS_BRANCH}\" == \"master\" && \"${TEST_TYPE}\" == \"acceptance-test\" ]] && { ./travis_publish_results.sh target/*.zip hsac-fitnesse-fixtures-snapshot-standalone.zip; python travis_add_server.py; mvn -DskipTests deploy --settings ~/.m2/mySettings.xml; };"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ cache:
   - $HOME/.m2
 
 script:
-  - travis_wait 60 ./travis_build_and_test.sh
+  - ./travis_build_and_test.sh
 
 after_success:
   - "[[ \"${TRAVIS_PULL_REQUEST}\" == \"false\" && \"${TRAVIS_BRANCH}\" == \"master\" && \"${TEST_TYPE}\" == \"acceptance-test\" ]] && { ./travis_publish_results.sh target/*.zip hsac-fitnesse-fixtures-snapshot-standalone.zip; python travis_add_server.py; mvn -DskipTests deploy --settings ~/.m2/mySettings.xml; };"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,17 @@ env:
 cache:
   directories:
   - $HOME/.m2
+  - "travis_phantomjs"
+
+before_install:
+  - "phantomjs --version"
+  - "export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH"
+  - "hash -d phantomjs || true"
+  - "phantomjs --version"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then wget https://assets.membergetmember.co/software/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2; fi"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then tar -xvf $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; fi"
+  - "phantomjs --version"
 
 script:
   - ./travis_build_and_test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ cache:
 before_install:
   - "phantomjs --version"
   - "export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH"
-  - "hash -d phantomjs || true"
   - "phantomjs --version"
   - "if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi"
   - "if [ $(phantomjs --version) != '2.1.1' ]; then wget https://assets.membergetmember.co/software/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2; fi"

--- a/wiki/FitNesseRoot/HsacAcceptanceTests/SlimTests/BrowserTest/FileUploadTest.wiki
+++ b/wiki/FitNesseRoot/HsacAcceptanceTests/SlimTests/BrowserTest/FileUploadTest.wiki
@@ -1,7 +1,3 @@
----
-Help: Skipped because PhantomJs on Linux seems to crash when using file inputs.
-Prune
----
 This test ensures we can deal with file upload inputs.
 
 !define HTML { {{{


### PR DESCRIPTION
Using phantom 2.1.1 on travis (instead of 1.x.x) should make build more stable, and allows file upload