### PR TITLE
Resemble curl's content-disposition header when posting a file

### DIFF
--- a/src/main/java/nl/hsac/fitnesse/fixture/util/HttpClient.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/HttpClient.java
@@ -85,7 +85,7 @@ public class HttpClient {
         HttpPost methodPost = new HttpPost(url);
 
         MultipartEntityBuilder builder = MultipartEntityBuilder.create();
-        builder.addBinaryBody(file.getName(), file,
+        builder.addBinaryBody("file", file,
                 ContentType.APPLICATION_OCTET_STREAM, file.getName());
         HttpEntity multipart = builder.build();
 


### PR DESCRIPTION
Changed post method in HttpClient to resemble curl's behaviour when posting a file. Fixes compatibility with some api's that are sensitive to it.

Currently, when posting a file using HttpTest, the disposition request header contains:
Content-Disposition: form-data; name="filename.ext"; filename="filename.ext"

This results in files not being read by the blazemeter REST API.
Posting the same file using Curl, the disposition header reads:
Content-Disposition: form-data; name="file"; filename="filename.ext"

That request is read correctly.

This minor change fixes the post method for posting binaries in HttpClient to behave in the same way as curl does. 
