### PR TITLE
Updated date format fixture to be able to work with localized date strings

### DIFF
--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/DateFormatFixture.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/DateFormatFixture.java
@@ -4,6 +4,7 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 import java.util.TimeZone;
 
 /**
@@ -12,19 +13,25 @@ import java.util.TimeZone;
 public class DateFormatFixture extends SlimFixture {
     private String dateFormat;
     private TimeZone timezone;
+    private String locale;
     private boolean timestampHasMilliseconds = true;
 
     public DateFormatFixture() {
-        this(getDefaultFormat(), getDefaultTimeZone());
+        this(getDefaultFormat(), getDefaultTimeZone(), getDefaultLocale());
     }
 
     public DateFormatFixture(String dateformat) {
-        this(dateformat, getDefaultTimeZone());
+        this(dateformat, getDefaultTimeZone(), getDefaultLocale());
     }
 
     public DateFormatFixture(String dateformat, String timezone) {
+        this(dateformat, timezone, getDefaultLocale());
+    }
+
+    public DateFormatFixture(String dateformat, String timezone, String locale) {
         setDateFormat(dateformat);
         setTimezone(timezone);
+        setLocale(locale);
     }
 
     public void setDateFormat(String df) {
@@ -33,6 +40,10 @@ public class DateFormatFixture extends SlimFixture {
 
     public void setTimezone(String newTimezone) {
         timezone = TimeZone.getTimeZone(newTimezone);
+    }
+
+    public void setLocale(String locale) {
+        this.locale = locale;
     }
 
     public void timestampHasMilliseconds(boolean hasMillis) {
@@ -101,7 +112,7 @@ public class DateFormatFixture extends SlimFixture {
     }
 
     protected SimpleDateFormat getDateFormat(String dateFormat) {
-        SimpleDateFormat sdf = new SimpleDateFormat(dateFormat);
+        SimpleDateFormat sdf = new SimpleDateFormat(dateFormat, Locale.forLanguageTag(locale));
         sdf.setTimeZone(timezone);
         return sdf;
     }
@@ -113,5 +124,7 @@ public class DateFormatFixture extends SlimFixture {
     protected static String getDefaultTimeZone() {
         return TimeZone.getDefault().getID();
     }
+
+    protected static String getDefaultLocale() { return Locale.getDefault().getLanguage(); }
 }
 

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/UtilityFixtures/DateFormatFixture.wiki
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/UtilityFixtures/DateFormatFixture.wiki
@@ -84,3 +84,14 @@ Now the calls to the formatting methods behave differently again (the date might
 |show  |format timestamp|$stamp|as|yyyy/MM/dd HH:mm:ss|
 |show  |format timestamp|$stamp                       |
 
+It's also possible to use an locale that is not your default locale:
+
+|library                                                  |
+|date format fixture|EEE, MMM dd yyyy HH:mm:ss z|UTC|en_US|
+
+Now we can also convert localized date strings:
+
+|script|string fixture                                                       |
+|show  |format date     |Thu, Dec 14 2017 11:50:00 UTC|as|dd-MM-yyyy HH:mm:ss|
+|show  |format timestamp|$stamp                                              |
+


### PR DESCRIPTION
Extra constructor option for DateFormatFixture so that we can also translate to and from date strings that are formatted using local acronyms or day/month names.

See the example page for a usage example.