### PR TITLE
Updated Freemarker to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
 		<dependency>
 			<groupId>org.freemarker</groupId>
 			<artifactId>freemarker</artifactId>
-			<version>2.3.23</version>
+			<version>2.3.27-incubating</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Latest versions of freemarker allow for (among other things) auto-escaping of non-valid xml characters (such as ampersand) to reduce the risk of generating invalid requests.

See: https://freemarker.apache.org/docs/dgui_misc_autoescaping.html

We can now start a freemarker xml template with `<#ftl output_format="XML">` to enable automatic escaping.