### PR TITLE
Allow starting IE with capabilities and give an example

### DIFF
--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/web/SeleniumDriverSetup.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/web/SeleniumDriverSetup.java
@@ -54,7 +54,7 @@ public class SeleniumDriverSetup extends SlimFixture {
     /**
      * Creates an instance of the specified class an injects it into SeleniumHelper, so other fixtures can use it.
      * @param driverClassName name of Java class of WebDriver to use.
-     * @param profile profile to use (for firefox only for now)
+     * @param profile profile to use (for firefox, chrome mobile and IE only for now)
      * @return true if instance was created and injected into SeleniumHelper.
      * @throws Exception if no instance could be created.
      */
@@ -83,7 +83,7 @@ public class SeleniumDriverSetup extends SlimFixture {
      * (using defaults to determine the correct class and configuration properties).
      * and injects it into SeleniumHelper, so other fixtures can use it.
      * @param browser name of browser to connect to.
-     * @param profile setting of the browser (works now only for firefox)
+     * @param profile setting of the browser (for firefox, chrome mobile and IE only for now)
      * @return true if instance was created and injected into SeleniumHelper.
      * @throws Exception if no instance could be created.
      */

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/selenium/driverfactory/LocalDriverFactory.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/selenium/driverfactory/LocalDriverFactory.java
@@ -7,6 +7,8 @@ import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.FirefoxProfile;
+import org.openqa.selenium.ie.InternetExplorerDriver;
+import org.openqa.selenium.ie.InternetExplorerOptions;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 import java.util.Map;
@@ -43,6 +45,9 @@ public class LocalDriverFactory implements DriverFactory {
             } else if ("chromedriver".equalsIgnoreCase(driverClass.getSimpleName())) {
                 DesiredCapabilities capabilities = getChromeMobileCapabilities(profile);
                 driver = new ChromeDriver(capabilities);
+            } else if ("internetexplorerdriver".equalsIgnoreCase(driverClass.getSimpleName())) {
+                InternetExplorerOptions ieOptions = getInternetExplorerOptions(profile);
+                driver = new InternetExplorerDriver(ieOptions);
             } else {
                 driver = driverClass.newInstance();
             }
@@ -107,5 +112,15 @@ public class LocalDriverFactory implements DriverFactory {
             capabilities.setCapability(ChromeOptions.CAPABILITY, profile);
         }
         return capabilities;
+    }
+
+    public static InternetExplorerOptions getInternetExplorerOptions(Map<String, Object> profile) {
+        InternetExplorerOptions ieOptions = new InternetExplorerOptions();
+        if (profile != null) {
+            for (Map.Entry<String, Object> profileEntry : profile.entrySet()) {
+                ieOptions.setCapability(profileEntry.getKey(), profileEntry.getValue());
+            }
+        }
+        return ieOptions;
     }
 }

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/BrowserTests/SuiteSetUp.wiki
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/BrowserTests/SuiteSetUp.wiki
@@ -39,6 +39,14 @@ The latter allows tests to be executed on different operating systems. This is a
 |$chromeHeadlessProfile=|copy map               |
 *!
 
+!*> Define $ieCleanSession internet explorer profile
+
+|script                                |map fixture                       |
+|expand periods in names to nested maps|false                             |
+|set boolean value                     |true|for|!-ie.ensureCleanSession-!|
+|$ieCleanSession=                      |copy map                          |
+*!
+
 |script          |selenium driver setup                                                                                                                  |
 |start driver for|chrome                                                                                                                                 |
 |note            |start driver for     |!-MicrosoftEdge-!                                                                                                |
@@ -48,6 +56,8 @@ The latter allows tests to be executed on different operating systems. This is a
 |note            |start driver for     |chrome mobile emulation|with profile          |!{deviceName:Apple iPhone 6}                                      |
 |note            |start driver for     |chrome mobile emulation|with profile          |$mobileEmulation                                                  |
 |note            |start driver for     |chrome                 |with profile          |$chromeHeadlessProfile                                            |
+|note            |Starting internet explorer with a clean session is destructive, i.e. clears cookies, cache, history and saved form data ''globally''   |
+|note            |start driver for     |internet explorer      |with profile          |$ieCleanSession                                                   |
 |note            |connect to driver for|chrome                 |at                    |${GRID_HUB}                                                       |
 |note            |connect to driver for|!-MicrosoftEdge-!      |at                    |${GRID_HUB}                                                       |
 |note            |connect to driver for|internet explorer      |at                    |${GRID_HUB}                                                       |


### PR DESCRIPTION
We wanted to use the "ie.ensureCleanSession" capability with internet explorer but couldn't, so I added the possibility to hsac. Had a bit of spare time today to turn it into a pull request so that others may benefit from it, too