### PR TITLE
Allow enabling and disabling content compression support

### DIFF
--- a/src/main/java/nl/hsac/fitnesse/fixture/Environment.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/Environment.java
@@ -767,4 +767,18 @@ public class Environment {
     public void setPropertiesHelper(PropertiesHelper propertiesHelper) {
         this.propertiesHelper = propertiesHelper;
     }
+
+    /**
+     * Enables content compression support on this environment's HttpClient
+     */
+    public void enableHttpClientCompression() {
+        httpClient.enableCompression();
+    }
+
+    /**
+     * Disables content compression support on this environment's HttpClient
+     */
+    public void disableHttpClientCompression() {
+        httpClient.disableCompression();
+    }
 }

--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/HttpTest.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/HttpTest.java
@@ -53,6 +53,20 @@ public class HttpTest extends SlimFixtureWithMap {
     }
 
     /**
+     * Enables content compression support in the current environment (i.e. for the entire test run)
+     */
+    public void enableCompression() {
+        getEnvironment().enableHttpClientCompression();
+    }
+
+    /**
+     * Disables content compression support in the current environment (i.e. for the entire test run)
+     */
+    public void disableCompression() {
+        getEnvironment().disableHttpClientCompression();
+    }
+
+    /**
      * Stores value to be passed as headers.
      * @param value value to be passed.
      * @param name name to use this value for.

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests.wiki
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests.wiki
@@ -14,14 +14,15 @@ The >HttpPost2UsingScenarioTest makes multiple SOAP calls to a service, where sc
 >JsonHttpTest shows examples with GET, POST, AND PUT, using [[!-JsonPath-!][http://goessner.net/articles/JsonPath/]] to perform checks on the response.
 >HttpGetFollowRedirectTest shows checking the redirect sent by a server instead of following it.
 >HttpCookieHandling shows how cookie handling can be configured.
->HttpHeadTest shows an example HEAD request, retrieving only respsonse status and headers.
+>HttpHeadTest shows an example HEAD request, retrieving only response status and headers.
+>HttpCompressionTest shows an example GET request with gzip compression support.
 
 !2 Language
 
 !3 !-HttpTest-!
 The main commands/keywords (i.e. public methods) offered by !-nl.hsac.fitnesse.fixture.slim.HttpTest-! are listed below.
 
--|Comment                                                                                                                                                                                                                                         |
+-|Comment                                                                                                                                                                                                                                                       |
 |get from <url>                                                        |Sends a GET to the specified url (parameters can be added using 'set value(s) for').                                                                                                    |
 |get from <url> no redirect                                            |Sends a GET to the specified url not following redirects sent by the server.                                                                                                            |
 |get file from <url>                                                   |Sends a GET to the specified url, saving the response as file.                                                                                                                          |
@@ -74,7 +75,8 @@ The main commands/keywords (i.e. public methods) offered by !-nl.hsac.fitnesse.f
 |repeat at most	times                                                  |Returns the maximum number of requests sent by 'repeat until ...' commands.                                                                                                             |
 |set repeat interval to <interval> milliseconds                        |Sets the number of milliseconds between requests sent by 'repeat until ...' commands.                                                                                                   |
 |repeat interval                                                       |Returns the number of milliseconds between requests sent by 'repeat until ...' commands.                                                                                                |
-
+|enable compression                                                    |Enables content compression support (e.g. gzip) for all subsequent requests until the end of the test run                                                                               |
+|disable compression                                                   |Disables content compression support for all subsequent requests until the end of the test run (this is the default state)                                                              |
 
 !3 !-JsonHttpTest-!
 The commands/keywords (i.e. public methods) added by !-nl.hsac.fitnesse.fixture.slim.JsonHttpTest-! are listed below.

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/HttpCompressionTest.wiki
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/HttpTests/HttpCompressionTest.wiki
@@ -1,0 +1,12 @@
+!2 Http GET with gzip compression support
+
+Performs HTTP GET with gzip compression support.
+
+|script  |http test                                            |
+|enable compression                                            |
+|get from|http://fakerestapi.azurewebsites.net/api/activities/1|
+|show    |response                                             |
+
+Note that the Content-Encoding header is automatically removed after the content is decoded, so |show|response header|Content-Encoding| will show null regardless of actual encoding. Tools like Wireshark will allow you to see if the content was really sent gzipped.
+
+Also note that 'enable compression' lasts for the rest of the test run, or until you call 'disable compression'.


### PR DESCRIPTION
This PR is meant to fix #56. I tried to write tests for it, but the mockXmlServer does not seem suited to feed binary data to apache's HttpClient. I tested it by hand using the following test page:
```
|script  |http test                                            |
|note    |Test normal request without compression support      |
|get from|http://fakerestapi.azurewebsites.net/api/activities/1|
|show    |response                                             |

|script                                                         |
|note     |Force gzip compression (this should give gibberish)  |
|set value|gzip        |for header       |Accept-Encoding       |
|get from |http://fakerestapi.azurewebsites.net/api/activities/1|
|show     |response                                             |

|script                                                             |
|note    |Enable compression (should give a readable response again)|
|enable compression                                                 |
|get from|http://fakerestapi.azurewebsites.net/api/activities/1     |
|show    |response                                                  |

|script                                                                                                                                |
|note    |Disable the forced gzip compression                                                                                          |
|note    |Apache !-HttpClient-! adds its own Accept-Encoding, so response is still gzipped                                             |
|note    |(use Wireshark or similar to verify this, as apache !-HttpClient-! removes Content-Encoding from the response after decoding)|
|clear header values                                                                                                                   |
|get from|http://fakerestapi.azurewebsites.net/api/activities/1                                                                        |
|show    |response                                                                                                                     |

|script                                                        |
|note    |Disable compression and do a normal request again    |
|disable compression                                           |
|get from|http://fakerestapi.azurewebsites.net/api/activities/1|
|show    |response                                             |

|script                                                              |
|note     |Force gzip compression again (should give gibberish again)|
|set value|gzip         |for header         |Accept-Encoding         |
|get from |http://fakerestapi.azurewebsites.net/api/activities/1     |
|show     |response                                                  |
```
Comments on the coding style welcome; I tried to follow the style of the code base as closely as possible, but my Java is somewhat rusty 🙂