### PR TITLE
Hold back obscured element click exceptions in Firefox and Edge

### DIFF
--- a/wiki/FitNesseRoot/HsacAcceptanceTests/SlimTests/BrowserTest/ClickTemporarilyCoveredLinkTest.wiki
+++ b/wiki/FitNesseRoot/HsacAcceptanceTests/SlimTests/BrowserTest/ClickTemporarilyCoveredLinkTest.wiki
@@ -1,0 +1,38 @@
+This test ensures a link is still clicked when it is covered by another element, but is uncovered before the timout expires. This is a common pattern where AJAX is involved, when a loading spinner covers a clickable element until the AJAX request has finished.
+
+!define HTML { {{{
+<html>
+<body onload="startRemoveCoverTimer()">
+<div style="width: 200px; height: 200px; position: relative">
+	<a href="">The Link</a>
+	<div id="cover" style="position: absolute; top: 0; left: 0; right: 0; bottom: 0; background-color: rgba(255, 255, 255, 0.5)"></div>
+</div>
+<script type="text/javascript">
+	function startRemoveCoverTimer() {
+    	setTimeout(removeCover, 2000);
+    }
+
+    function removeCover() {
+    	document.getElementById('cover').style.display = 'none';
+    }
+</script>
+</body>
+</html>}}} }
+
+!*> Mock server
+
+|script      |mock xml server setup|
+|add response|${HTML}              |
+|add response|${HTML}              |
+|$url=       |get mock server url  |
+
+*!
+
+|script                |browser test|
+|open                  |$url        |
+|seconds before timeout|4           |
+|click                 |The Link    |
+
+|script|mock xml server setup|
+|stop                        |
+


### PR DESCRIPTION
When performing a `|click|` on an element that is obscured (i.e. hidden behind a different element) with Chrome (or IE), hsac will keep trying until timeout. This is a very useful feature on sites that cover elements with a loading spinner while AJAX is running. Firefox and Edge, however, just throw an exception and fail the test when an element is obscured. This PR aims to make Firefox and Edge behave like Chrome in that regard.

The original intent was to make all supported browsers behave like Chrome, but I ran into issues there. Safari does throw an exception when trying to click an obscured element, but it is too generic to filter:

```org.openqa.selenium.WebDriverException: An unknown server-side error occurred while processing the command. (WARNING: The server did not provide any stacktrace information)```

PhantomJS, on the other hand, just clicks the element whether it's obscured or not. No exceptions are thrown, but it will click too early in most AJAX situations.

To summarize, this PR changes browser behavior as follows:

**Old:**

| Browser | Behavior when \|click\|-ing an obscured element |
|---|---|
| Chrome, IE | Keeps trying to click until unobscured or timeout |
| Firefox, Edge, Safari | Immediately throws an exception |
| PhantomJS | Immediately clicks the element regardless of obscured or not |

**New:**

| Browser | Behavior when \|click\|-ing an obscured element |
|---|---|
| Chrome, IE, Firefox, Edge | Keeps trying to click until unobscured or timeout |
| Safari | Immediately throws an exception |
| PhantomJS | Immediately clicks the element regardless of obscured or not |