### PR TITLE
Fix the %d to resemble the actual bit prefix.

### DIFF
--- a/src/main/java/nl/hsac/fitnesse/fixture/util/selenium/driverfactory/ProjectDriverFactoryFactory.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/selenium/driverfactory/ProjectDriverFactoryFactory.java
@@ -65,9 +65,11 @@ public class ProjectDriverFactoryFactory {
     }
 
     protected String getExecutable(String basename) {
-        String name = getExecutableForOs(basename);
+        String name = null;
+
         for (int bit : new int[] {32, 64}) {
-            String exec = String.format(name, bit);
+            name = getExecutableForOs(basename, bit);
+            String exec = String.format(name);
             String execPath = getAbsoluteWebDriverPath(exec);
             if (execPath != null) {
                 name = execPath;
@@ -91,15 +93,15 @@ public class ProjectDriverFactoryFactory {
         return path;
     }
 
-    protected String getExecutableForOs(String basename) {
+    protected String getExecutableForOs(String basename, int bit) {
         String name = basename;
         String os = System.getProperty("os.name").toLowerCase();
         if (os.contains("win")) {
-            name = basename + "-windows-%dbit.exe";
+            name = basename + "-windows-"+bit+"bit.exe";
         } else if (os.contains("mac")) {
-            name = basename + "-mac-%dbit";
+            name = basename + "-mac-"+bit+"bit";
         } else if (os.contains("linux")) {
-            name = basename + "-linux-%dbit";
+            name = basename + "-linux-"+bit+"bit";
         }
         return name;
     }


### PR DESCRIPTION
When calling my tests binary, I get this stack
```
_EXCEPTION__:java.lang.IllegalStateException: The driver executable does not exist: /XXXX/fitnesse/chromedriver-linux-%dbit
```
I think there somehow was this digit-part in the code, the prevented fitnesse finding the actual executable `chromedriver-linux-64bit`.