### PR TITLE
Add Firefox's "can't access dead object" to isStaleElementException

### DIFF
--- a/src/main/java/nl/hsac/fitnesse/fixture/util/selenium/SeleniumHelper.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/selenium/SeleniumHelper.java
@@ -924,8 +924,8 @@ public class SeleniumHelper<T extends WebElement> {
             if (msg != null) {
                 result = msg.contains("Element does not exist in cache") // Safari stale element
                         || msg.contains("unknown error: unhandled inspector error: {\"code\":-32000,\"message\":\"Cannot find context with specified id\"}") // chrome error
-                        || msg.contains("Error: element is not attached to the page document"); // Alternate Chrome stale element
-
+                        || msg.contains("Error: element is not attached to the page document") // Alternate Chrome stale element
+                        || msg.contains("can't access dead object"); // Firefox stale element
             }
         }
         return result;


### PR DESCRIPTION
This PR adds "can't access dead object" as a possible content of a WebDriverException to `SeleniumHelper.isStaleElementException`, to fix the second problem reported in #231. I managed to create a test that almost 100% of the time generates such an exception when run with Firefox:

https://gist.githubusercontent.com/JessefSpecialisterren/1d8e8d256724aac09c6d8a5ff16c626e/raw/e03f4feaba8eab60025db93ec51c772138e064ab/DeadObjectExceptionTest.wiki

With this PR applied, the test comes to a normal failure as it should 🙂. Feedback welcome!