### PR TITLE
Fixed some acceptance tests

### DIFF
--- a/wiki/FitNesseRoot/HsacAcceptanceTests/SlimTests/BrowserTest/RichFacesTest.wiki
+++ b/wiki/FitNesseRoot/HsacAcceptanceTests/SlimTests/BrowserTest/RichFacesTest.wiki
@@ -5,12 +5,11 @@ Unfortunately we can't check with local server (since we don't want to set up al
 We ensure we can properly wait for richfaces ajax to render elements.
 
 |script                |rich faces test                                                           |
-|open                  |https://www.triodos.nl/nl/particulieren/betaalrekening/form-opening-tibet/|
-|click                 |Vul uw gegevens in                                                        |
+|open                  |https://www.triodos.nl/internet-betaalrekening                            |
+|click                 |Direct openen                                                             |
 |seconds before timeout|2                                                                         |
 |enter                 |f                          |as                     |Voorletters           |
 |check                 |value of                   |Voorletters            |F.                    |
 |enter                 |fitnesse                   |as                     |Achternaam            |
 |check                 |value of                   |Achternaam             |Fitnesse              |
 |show                  |take screenshot            |rf                                            |
-

--- a/wiki/FitNesseRoot/HsacAcceptanceTests/SlimTests/HttpTest/HttpGetFileTest.wiki
+++ b/wiki/FitNesseRoot/HsacAcceptanceTests/SlimTests/HttpTest/HttpGetFileTest.wiki
@@ -1,7 +1,6 @@
 ---
 Help: Ensure we can download from a url to file
 ---
-
 |script      |mock xml server setup|
 |add response|Downloaded text      |
 |$url=       |get mock server url  |
@@ -15,10 +14,9 @@ Help: Ensure we can download from a url to file
 |check |base name of|$file|!-FitNesseMock-!|
 |check |extension of|$file|txt             |
 |check |text in     |$file|Downloaded text |
-
+|delete|$file                              |
 
 |table: Mock Server Message Report|
 
 |script|mock xml server setup|
 |stop                        |
-

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/UtilityFixtures/FileFixture.wiki
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/UtilityFixtures/FileFixture.wiki
@@ -14,57 +14,58 @@ Filenames may be manipulated.
 002
 last one!-!}
 
-|script            |file fixture                                                              |
-|note              |default directory used by the fixture is inside the files section         |
-|$def_dir=         |get directory                                                             |
-|$created=         |create      |bye1.txt                    |containing|Bye Bye 1            |
-|poll until        |$created    |exists                                                       |
-|poll until size of|$created    |exceeds                     |0                               |
-|check             |text in     |$created                    |Bye Bye 1                       |
-|check             |filename of |$created                    |bye1.txt                        |
-|check             |base name of|$created                    |bye1                            |
-|check             |extension of|$created                    |txt                             |
-|ensure            |exists      |$created                                                     |
-|delete            |$created                                                                  |
-|reject            |exists      |$created                                                     |
-|                  |deleting non-existing file does not work: throws exception                |
-|                  |but ensuring non-existing file does not exist is no problem, returns false|
-|reject            |delete      |$created                    |if exists                       |
-|poll until        |$created    |does not exist                                               |
-|note              |directory to be used by the fixture can be set to inside the files section|
-|set directory     |http://files/test                                                         |
-|$created2=        |create      |bye2.txt                    |containing|Bye Bye 2            |
-|check             |text in     |$created2                   |Bye Bye 2                       |
-|delete            |$created2   |if exists                                                    |
-|note              |directory to be used by the fixture can be set to system path             |
-|set directory     |${DIR}                                                                    |
-|show              |create      |bye.txt                     |containing|Bye Bye 3            |
-|check             |size of     |bye.txt                     |9                               |
-|check             |text in     |bye.txt                     |Bye Bye 3                       |
-|set value         |John        |for                         |name                            |
-|show              |create      |greeting.txt                |using     |greeting.ftl         |
-|check             |text in     |greeting.txt                |Hello John                      |
-|set value         |John        |for                         |name                            |
-|show              |create      |greeting.html               |using     |greeting.ftl.html    |
-|show              |text in     |greeting.html                                                |
-|show              |content of  |greeting.html                                                |
-|note              |filename's containing either / or \ will point to sub-directories         |
-|show              |copy        |${DIR}/greeting.txt         |to        |copy/greetingCopy.txt|
-|check             |text in     |${DIR}\copy\greetingCopy.txt|Hello John                      |
-|check             |filename of |${DIR}\copy\greetingCopy.txt|greetingCopy.txt                |
-|check             |base name of|${DIR}\copy\greetingCopy.txt|greetingCopy                    |
-|check             |extension of|${DIR}\copy\greetingCopy.txt|txt                             |
-|note              |you can create a new file by "appending" one line into it                 |
-|set directory     |http://files/test                                                         |
-|$appended=        |append      |first                       |to        |appended.txt         |
-|check             |text in     |$appended                   |first                           |
-|note              |you can append content to an existing file                                |
-|append            |!- line-!   |to                          |$appended                       |
-|check             |text in     |$appended                   |first line                      |
-|note              |you can append content as a new line to an existing file                  |
-|append            |second line |to                          |$appended |on new line          |
-|check             |text in     |$appended                                                    |!-first line
-second line-!                |
+|script                 |file fixture                                                              |
+|note                   |default directory used by the fixture is inside the files section         |
+|$def_dir=              |get directory                                                             |
+|$created=              |create      |bye1.txt                    |containing|Bye Bye 1            |
+|poll until             |$created    |exists                                                       |
+|poll until size of     |$created    |exceeds                     |0                               |
+|check                  |text in     |$created                    |Bye Bye 1                       |
+|check                  |filename of |$created                    |bye1.txt                        |
+|check                  |base name of|$created                    |bye1                            |
+|check                  |extension of|$created                    |txt                             |
+|ensure                 |exists      |$created                                                     |
+|delete                 |$created                                                                  |
+|reject                 |exists      |$created                                                     |
+|                       |deleting non-existing file does not work: throws exception                |
+|                       |but ensuring non-existing file does not exist is no problem, returns false|
+|reject                 |delete      |$created                    |if exists                       |
+|poll until             |$created    |does not exist                                               |
+|note                   |directory to be used by the fixture can be set to inside the files section|
+|set directory          |http://files/test                                                         |
+|$created2=             |create      |bye2.txt                    |containing|Bye Bye 2            |
+|check                  |text in     |$created2                   |Bye Bye 2                       |
+|delete                 |$created2   |if exists                                                    |
+|note                   |directory to be used by the fixture can be set to system path             |
+|set directory          |${DIR}                                                                    |
+|show                   |create      |bye.txt                     |containing|Bye Bye 3            |
+|check                  |size of     |bye.txt                     |9                               |
+|check                  |text in     |bye.txt                     |Bye Bye 3                       |
+|set value              |John        |for                         |name                            |
+|show                   |create      |greeting.txt                |using     |greeting.ftl         |
+|check                  |text in     |greeting.txt                |Hello John                      |
+|set value              |John        |for                         |name                            |
+|show                   |create      |greeting.html               |using     |greeting.ftl.html    |
+|show                   |text in     |greeting.html                                                |
+|show                   |content of  |greeting.html                                                |
+|note                   |filename's containing either / or \ will point to sub-directories         |
+|show                   |copy        |${DIR}/greeting.txt         |to        |copy/greetingCopy.txt|
+|check                  |text in     |${DIR}\copy\greetingCopy.txt|Hello John                      |
+|check                  |filename of |${DIR}\copy\greetingCopy.txt|greetingCopy.txt                |
+|check                  |base name of|${DIR}\copy\greetingCopy.txt|greetingCopy                    |
+|check                  |extension of|${DIR}\copy\greetingCopy.txt|txt                             |
+|note                   |you can create a new file by "appending" one line into it                 |
+|set directory          |http://files/test                                                         |
+|$appended=             |append      |first                       |to        |appended.txt         |
+|check                  |text in     |$appended                   |first                           |
+|note                   |you can append content to an existing file                                |
+|append                 |!- line-!   |to                          |$appended                       |
+|check                  |text in     |$appended                   |first line                      |
+|note                   |you can append content as a new line to an existing file                  |
+|append                 |second line |to                          |$appended |on new line          |
+|convert line endings of|$appended   |to unix                                                      |
+|check                  |text in     |$appended                                                    |!-first line
+second line-! |
 |convert line endings of|$appended|to windows  |
 |check                  |size of  |$appended|23|
 |convert line endings of|$appended|to unix     |


### PR DESCRIPTION
Some Slim acceptance tests were failing. Fixed the following:
- RichFaces test was failing because triodos.nl was changed -> Changed url and button to click.
- FileTest failed on Windows because of a line endings issue -> Explicitly set line endings to Unix style before check. 
- HttpGetFileTest could only be run once, subsequent runs failed, because old mock response file was never deleted and newly created mock response files got an unexpected name. -> Added deletion of mock response file to the test. 


