### PR TITLE
Ensuring testDelete can run on its own

### DIFF
--- a/src/test/java/nl/hsac/fitnesse/fixture/slim/FileFixtureTest.java
+++ b/src/test/java/nl/hsac/fitnesse/fixture/slim/FileFixtureTest.java
@@ -144,7 +144,10 @@ public class FileFixtureTest {
     public void testDelete() {
         try {
             fixture.setDirectory(testResourcesDir);
+            fixture.copyTo(txtFilename, copyFilename);
             fixture.delete(copyFilename);
+        } catch (IOException ioe) {
+            fail("Should not happen: " + ioe.getMessage());
         } catch (SlimFixtureException sfe) {
             fail("Should not happen: " + sfe.getMessage());
         }

--- a/src/test/java/nl/hsac/fitnesse/fixture/slim/FileFixtureTest.java
+++ b/src/test/java/nl/hsac/fitnesse/fixture/slim/FileFixtureTest.java
@@ -146,10 +146,8 @@ public class FileFixtureTest {
             fixture.setDirectory(testResourcesDir);
             fixture.copyTo(txtFilename, copyFilename);
             fixture.delete(copyFilename);
-        } catch (IOException ioe) {
-            fail("Should not happen: " + ioe.getMessage());
-        } catch (SlimFixtureException sfe) {
-            fail("Should not happen: " + sfe.getMessage());
+        } catch (Exception ex) {
+            fail("Should not happen: " + ex.getMessage());
         }
     }
 }


### PR DESCRIPTION
Currently, testDelete fails when run on its own, because the file to delete initially does not exist. This pull request copies the file into position first before deleting.

Please let me know if you want to discuss the changes more.