### PR TITLE
Move browser window

### DIFF
--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/web/BrowserTest.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/web/BrowserTest.java
@@ -28,10 +28,13 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.Cookie;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.Point;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.UnhandledAlertException;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebDriver.TargetLocator;
+import org.openqa.selenium.WebDriver.Window;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
@@ -1080,6 +1083,16 @@ public class BrowserTest<T extends WebElement> extends SlimFixture {
             }
             return ok;
         });
+    }
+
+    /**
+     * Check the value of a web element repeatedly until it contains an expected
+     * value, i.e., "Processing..." becomes "Done."
+     */
+    @WaitUntil(TimeoutPolicy.STOP_TEST)
+    public boolean waitUntilIs(String place, String expected) {
+        WebElement element = getElementToRetrieveValue(place, null);
+        return hasText(element, expected);
     }
 
     protected String cleanExpectedValue(String expectedText) {
@@ -2320,6 +2333,20 @@ public class BrowserTest<T extends WebElement> extends SlimFixture {
     public void setBrowserSizeToMaximum() {
         getSeleniumHelper().setWindowSizeToMaximum();
     }
+
+    public void setBrowserPositionXY(int xPos, int yPos) {
+		WebDriver driver = driver();
+		String currentWindowHandle = driver.getWindowHandle();
+		TargetLocator aLocator = driver.switchTo();
+		aLocator.window(currentWindowHandle);
+		Window aWindow = driver.manage().window();
+		Point p = new Point(xPos, yPos);
+		aWindow.setPosition(p);
+	}
+
+    public void setBrowserPositionToHome() {
+		setBrowserPositionXY(0, 0);
+	}
 
     /**
      * Downloads the target of the supplied link.

--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/web/BrowserTest.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/web/BrowserTest.java
@@ -28,13 +28,10 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.Cookie;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.Keys;
-import org.openqa.selenium.Point;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.UnhandledAlertException;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebDriver.TargetLocator;
-import org.openqa.selenium.WebDriver.Window;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
@@ -2325,13 +2322,7 @@ public class BrowserTest<T extends WebElement> extends SlimFixture {
     }
 
     public void setBrowserPositionXY(int xPos, int yPos) {
-		WebDriver driver = driver();
-		String currentWindowHandle = driver.getWindowHandle();
-		TargetLocator aLocator = driver.switchTo();
-		aLocator.window(currentWindowHandle);
-		Window aWindow = driver.manage().window();
-		Point p = new Point(xPos, yPos);
-		aWindow.setPosition(p);
+		getSeleniumHelper().setBrowserPositionXY(xPos, yPos);
 	}
 
     public void setBrowserPositionToHome() {

--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/web/BrowserTest.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/web/BrowserTest.java
@@ -1085,16 +1085,6 @@ public class BrowserTest<T extends WebElement> extends SlimFixture {
         });
     }
 
-    /**
-     * Check the value of a web element repeatedly until it contains an expected
-     * value, i.e., "Processing..." becomes "Done."
-     */
-    @WaitUntil(TimeoutPolicy.STOP_TEST)
-    public boolean waitUntilIs(String place, String expected) {
-        WebElement element = getElementToRetrieveValue(place, null);
-        return hasText(element, expected);
-    }
-
     protected String cleanExpectedValue(String expectedText) {
         return cleanupValue(expectedText);
     }

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/selenium/SeleniumHelper.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/selenium/SeleniumHelper.java
@@ -30,6 +30,7 @@ import org.openqa.selenium.NoAlertPresentException;
 import org.openqa.selenium.NoSuchWindowException;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.Platform;
+import org.openqa.selenium.Point;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.TakesScreenshot;
@@ -1146,6 +1147,13 @@ public class SeleniumHelper<T extends WebElement> {
 
     public void setWindowSizeToMaximum() {
         getWindow().maximize();
+    }
+
+    public void setBrowserPositionXY(int xPos, int yPos) {
+		String currentWindowHandle = driver().getWindowHandle();
+		getTargetLocator().window(currentWindowHandle);
+		Point p = new Point(xPos, yPos);
+		getWindow().setPosition(p);
     }
 
     /**


### PR DESCRIPTION
Added two commands to move the browser window on the desktop, with Home as the upper-left corner of the desktop, usage:

<code>
| script | browser test |
|| move browser down 100 and over 200 pixels: |
|set browser position x | 200 | y | 100 |
|| Move window to UL corner: |
|set browser position to home |
</code>