### PR TITLE
Support map of capabilities for (chromium) edge, like chrome

### DIFF
--- a/src/main/java/nl/hsac/fitnesse/fixture/util/selenium/driverfactory/LocalDriverFactory.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/selenium/driverfactory/LocalDriverFactory.java
@@ -1,12 +1,10 @@
 package nl.hsac.fitnesse.fixture.util.selenium.driverfactory;
 
-import com.galenframework.generator.raycast.EdgesContainer;
 import nl.hsac.fitnesse.fixture.slim.SlimFixtureException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.edge.EdgeDriver;
-import org.openqa.selenium.edge.EdgeOptions;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.FirefoxProfile;

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/selenium/driverfactory/LocalDriverFactory.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/selenium/driverfactory/LocalDriverFactory.java
@@ -1,9 +1,12 @@
 package nl.hsac.fitnesse.fixture.util.selenium.driverfactory;
 
+import com.galenframework.generator.raycast.EdgesContainer;
 import nl.hsac.fitnesse.fixture.slim.SlimFixtureException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.edge.EdgeDriver;
+import org.openqa.selenium.edge.EdgeOptions;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.firefox.FirefoxProfile;
@@ -49,6 +52,9 @@ public class LocalDriverFactory implements DriverFactory {
             } else if ("internetexplorerdriver".equalsIgnoreCase(driverClass.getSimpleName())) {
                 InternetExplorerOptions ieOptions = getInternetExplorerOptions(profile);
                 driver = new InternetExplorerDriver(ieOptions);
+            } else if ("edgedriver".equalsIgnoreCase(driverClass.getSimpleName())) {
+                DesiredCapabilities edgeOptions = getChromiumEdgeOptions(profile);
+                driver = new EdgeDriver(edgeOptions);
             } else {
                 driver = driverClass.newInstance();
             }
@@ -131,5 +137,13 @@ public class LocalDriverFactory implements DriverFactory {
             }
         }
         return ieOptions;
+    }
+
+    public static DesiredCapabilities getChromiumEdgeOptions(Map<String, Object> profile) {
+        DesiredCapabilities capabilities = DesiredCapabilities.edge();
+        if(profile != null) {
+           capabilities.setCapability("ms:edgeOptions", profile);
+        }
+        return capabilities;
     }
 }

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/selenium/driverfactory/LocalDriverFactory.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/selenium/driverfactory/LocalDriverFactory.java
@@ -139,7 +139,7 @@ public class LocalDriverFactory implements DriverFactory {
 
     public static DesiredCapabilities getChromiumEdgeOptions(Map<String, Object> profile) {
         DesiredCapabilities capabilities = DesiredCapabilities.edge();
-        if(profile != null) {
+        if (profile != null) {
            capabilities.setCapability("ms:edgeOptions", profile);
         }
         return capabilities;


### PR DESCRIPTION
Since edge is now chromium based, we can also pass it a profile map to better parameterize it. (i.e. run headless, start-maximized set screen resolution, etc)

This PR ensures that when a a map is passed to startDriverForWithProfile and msedge is requested, that the profile map is applied as capabilities. (ms:edgeOptions capability)