### PR TITLE
Allow using plaintext http://files urls

### DIFF
--- a/src/main/java/nl/hsac/fitnesse/fixture/Environment.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/Environment.java
@@ -705,8 +705,9 @@ public class Environment {
     public String getFilePathFromWikiUrl(String wikiUrl) {
         String url = getHtmlCleaner().getUrl(wikiUrl);
         File file;
-        if (url.startsWith("files/")) {
-            String relativeFile = url.substring("files".length());
+        if (url.startsWith("files/") || url.startsWith("http://files/")) {
+            String prefix = url.startsWith("files/") ? "files" : "http://files";
+            String relativeFile = url.substring(prefix.length());
             relativeFile = relativeFile.replace('/', File.separatorChar);
             String pathname = getFitNesseFilesSectionDir() + relativeFile;
             file = new File(pathname);

--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/FileFixture.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/FileFixture.java
@@ -249,7 +249,7 @@ public class FileFixture extends SlimFixtureWithMap {
 
     private boolean isFilesUrl(String filename) {
         String url = getUrl(filename);
-        return !filename.equals(url) && url.startsWith("files/");
+        return (!filename.equals(url) && url.startsWith("files/")) || url.startsWith("http://files");
     }
 
     private String cleanupPath(String fullPath) {

--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/web/BrowserTest.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/web/BrowserTest.java
@@ -2822,7 +2822,7 @@ public class BrowserTest<T extends WebElement> extends SlimFixture {
     }
 
     /**
-     * Set the scroll into view behaviour to 'çenter of viewport' (true) or 'auto' (false)
+     * Set the scroll into view behaviour to 'center of viewport' (true) or 'auto' (false)
      * @param scrollElementsToCenterOfViewport True to scroll to center, False to use automatic scroll behaviour
      */
     public void scrollElementsToCenterOfViewport(boolean scrollElementsToCenterOfViewport) {

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/UtilityFixtures/FileFixture.wiki
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/UtilityFixtures/FileFixture.wiki
@@ -104,5 +104,8 @@ Table below shows how we can use a list of non-reusable data from a file:
 |check        |take first line from|list.txt  |last one!      |
 |show         |text in             |list.txt                  |
 
+Files-directory aliases (http://files/...) can be used to reference files in literal tables:
 
-
+!|script                                                                              |
+|append|NewContent|to                               |http://files/fileFixture/list.txt|
+|check |text in   |http://files/fileFixture/list.txt|NewContent                       |


### PR DESCRIPTION
Previously, http://files url's referencing the wiki's file section were not translated to an actual file path when they were not translated to a html link first when used with i.e. FileFixture.

This PR allows to use http://files references from a literal table (`!|table|`)