### PR TITLE
Fix Nondeterministic Ordering in Tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,12 @@
             <version>2.23.4</version>
             <scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.skyscreamer</groupId>
+			<artifactId>jsonassert</artifactId>
+			<version>1.5.0</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/JsonHttpTest.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/JsonHttpTest.java
@@ -1,12 +1,13 @@
 package nl.hsac.fitnesse.fixture.slim;
 
+import com.google.gson.Gson;
 import nl.hsac.fitnesse.fixture.util.DataUrlHelper;
 import nl.hsac.fitnesse.fixture.util.JsonPathHelper;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.entity.ContentType;
-import org.json.JSONObject;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 /**
@@ -28,7 +29,9 @@ public class JsonHttpTest extends HttpTest {
     }
 
     protected String jsonEncodeCurrentValues() {
-        return new JSONObject(getCurrentValues()).toString();
+        Gson gson = new Gson();
+        return gson.toJson(getCurrentValues(), LinkedHashMap.class);
+//        return new JSONObject(getCurrentValues()).toString();
     }
 
     protected String getContentTypeForJson() {

--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/JsonHttpTest.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/JsonHttpTest.java
@@ -31,7 +31,6 @@ public class JsonHttpTest extends HttpTest {
     protected String jsonEncodeCurrentValues() {
         Gson gson = new Gson();
         return gson.toJson(getCurrentValues(), LinkedHashMap.class);
-//        return new JSONObject(getCurrentValues()).toString();
     }
 
     protected String getContentTypeForJson() {

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/JsonHelper.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/JsonHelper.java
@@ -1,6 +1,8 @@
 package nl.hsac.fitnesse.fixture.util;
 
-import com.google.gson.*;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParser;
 import net.minidev.json.JSONArray;
 import nl.hsac.fitnesse.fixture.Environment;
 import org.apache.commons.lang3.StringUtils;
@@ -26,26 +28,15 @@ public class JsonHelper implements Formatter {
     public String format(String json) {
         String result = null;
         if (json != null){
+            Gson gson = new GsonBuilder().setPrettyPrinting().create();
+            JsonParser jsonParser = new JsonParser();
+
             if (json.startsWith("{")) {
-                // Fixed JsonHttpTestTest#testFormatJson
-                return new Gson().toJson(json);
+                return gson.toJson(jsonParser.parse(json).getAsJsonObject());
             } else if (json.startsWith("[")) {
-//                JSONObject jsonObject = new JSONObject("{'a': " + json + "}");
-//                org.json.JSONArray array = (org.json.JSONArray) jsonObject.get("a");
-//                result = array.toString(4);
-
-                JsonParser jsonParser = new JsonParser();
-                Gson gson = new GsonBuilder().setPrettyPrinting().create();
-                String prettyJson = gson.toJson(jsonParser.parse(json).getAsJsonArray().get(0).getAsJsonObject());
-                System.out.println( "json prettify"+ prettyJson);
-
-                org.json.JSONArray array = new org.json.JSONArray("[" + prettyJson + "]");
-                System.out.println(gson.toJson(array));
-
-                result = array.toString(4);
-
-//                JsonArray jsonArray1 = (JsonArray) new JsonParser().parse(json).getAsJsonArray();
-//                org.json.JSONArray array = (org.json.JSONArray) jsonObject.get("a");
+                String prettyJson;
+                prettyJson = gson.toJson(jsonParser.parse(json).getAsJsonArray());
+                result = prettyJson;
             }
         }
         return result;

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/JsonHelper.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/JsonHelper.java
@@ -32,7 +32,7 @@ public class JsonHelper implements Formatter {
             JsonParser jsonParser = new JsonParser();
 
             if (json.startsWith("{")) {
-                return gson.toJson(jsonParser.parse(json).getAsJsonObject());
+                result = gson.toJson(jsonParser.parse(json).getAsJsonObject());
             } else if (json.startsWith("[")) {
                 result = gson.toJson(jsonParser.parse(json).getAsJsonArray());
             }

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/JsonHelper.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/JsonHelper.java
@@ -1,5 +1,6 @@
 package nl.hsac.fitnesse.fixture.util;
 
+import com.google.gson.*;
 import net.minidev.json.JSONArray;
 import nl.hsac.fitnesse.fixture.Environment;
 import org.apache.commons.lang3.StringUtils;
@@ -26,11 +27,25 @@ public class JsonHelper implements Formatter {
         String result = null;
         if (json != null){
             if (json.startsWith("{")) {
-                result = new JSONObject(json).toString(4);
+                // Fixed JsonHttpTestTest#testFormatJson
+                return new Gson().toJson(json);
             } else if (json.startsWith("[")) {
-                JSONObject jsonObject = new JSONObject("{'a': " + json + "}");
-                org.json.JSONArray array = (org.json.JSONArray) jsonObject.get("a");
+//                JSONObject jsonObject = new JSONObject("{'a': " + json + "}");
+//                org.json.JSONArray array = (org.json.JSONArray) jsonObject.get("a");
+//                result = array.toString(4);
+
+                JsonParser jsonParser = new JsonParser();
+                Gson gson = new GsonBuilder().setPrettyPrinting().create();
+                String prettyJson = gson.toJson(jsonParser.parse(json).getAsJsonArray().get(0).getAsJsonObject());
+                System.out.println( "json prettify"+ prettyJson);
+
+                org.json.JSONArray array = new org.json.JSONArray("[" + prettyJson + "]");
+                System.out.println(gson.toJson(array));
+
                 result = array.toString(4);
+
+//                JsonArray jsonArray1 = (JsonArray) new JsonParser().parse(json).getAsJsonArray();
+//                org.json.JSONArray array = (org.json.JSONArray) jsonObject.get("a");
             }
         }
         return result;

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/JsonHelper.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/JsonHelper.java
@@ -34,9 +34,7 @@ public class JsonHelper implements Formatter {
             if (json.startsWith("{")) {
                 return gson.toJson(jsonParser.parse(json).getAsJsonObject());
             } else if (json.startsWith("[")) {
-                String prettyJson;
-                prettyJson = gson.toJson(jsonParser.parse(json).getAsJsonArray());
-                result = prettyJson;
+                result = gson.toJson(jsonParser.parse(json).getAsJsonArray());
             }
         }
         return result;

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/NamespaceContextImpl.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/NamespaceContextImpl.java
@@ -4,7 +4,7 @@ import fit.exception.FitFailureException;
 
 import javax.xml.namespace.NamespaceContext;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -13,7 +13,7 @@ import java.util.Map;
  * Implementation of namespace registry for XPath expressions.
  */
 public class NamespaceContextImpl implements NamespaceContext {
-    private final Map<String, String> namespaces = new HashMap<String, String>();
+    private final Map<String, String> namespaces = new LinkedHashMap<>();
 
     /**
      * Adds registration for prefix.

--- a/src/test/java/nl/hsac/fitnesse/fixture/slim/JsonHttpTestTest.java
+++ b/src/test/java/nl/hsac/fitnesse/fixture/slim/JsonHttpTestTest.java
@@ -23,9 +23,9 @@ public class JsonHttpTestTest {
                 "}</pre>";
 
         assertEquals(expected,
-                fixture.safeFormatValue("{\"price\": 8.95,\"category\": \"reference\"}").replace("\r", "").replace("\\", ""));
+                fixture.safeFormatValue("{\"price\": 8.95,\"category\": \"reference\"}").replace("\r", ""));
         assertEquals(expected,
-                fixture.safeFormatValue(" {\"price\": 8.95,\"category\": \"reference\"}").replace("\r", "").replace("\\", ""));
+                fixture.safeFormatValue(" {\"price\": 8.95,\"category\": \"reference\"}").replace("\r", ""));
     }
 
     @Test

--- a/src/test/java/nl/hsac/fitnesse/fixture/slim/JsonHttpTestTest.java
+++ b/src/test/java/nl/hsac/fitnesse/fixture/slim/JsonHttpTestTest.java
@@ -18,31 +18,33 @@ public class JsonHttpTestTest {
     @Test
     public void testFormatJson() {
         String expected = "<pre>{\n" +
-                "    &quot;price&quot;: 8.95,\n" +
-                "    &quot;category&quot;: &quot;reference&quot;\n" +
+                "  &quot;price&quot;: 8.95,\n" +
+                "  &quot;category&quot;: &quot;reference&quot;\n" +
                 "}</pre>";
 
         assertEquals(expected,
-                fixture.safeFormatValue("{\"category\": \"reference\",\"price\": 8.95}").replace("\r", ""));
+                fixture.safeFormatValue("{\"price\": 8.95,\"category\": \"reference\"}").replace("\r", "").replace("\\", ""));
         assertEquals(expected,
-                fixture.safeFormatValue(" {\"category\": \"reference\",\"price\": 8.95}").replace("\r", ""));
+                fixture.safeFormatValue(" {\"price\": 8.95,\"category\": \"reference\"}").replace("\r", "").replace("\\", ""));
     }
 
     @Test
     public void testFormatJsonArray() {
-        String expected = "<pre>[{\n" +
+        String expected = "<pre>[\n" +
+                "  {\n" +
                 "    &quot;category&quot;: &quot;reference&quot;,\n" +
                 "    &quot;nested&quot;: {\n" +
-                "        &quot;price&quot;: 8.95,\n" +
-                "        &quot;category&quot;: &quot;reference&quot;\n" +
+                "      &quot;price&quot;: 8.95,\n" +
+                "      &quot;category&quot;: &quot;reference&quot;\n" +
                 "    }\n" +
-                "}]</pre>";
+                "  }\n" +
+                "]</pre>";
 
         assertEquals(expected,
-                fixture.safeFormatValue("[{\"category\": \"reference\",\"nested\": {\"category\": \"reference\",\"price\": 8.95}}]").replace("\r", ""));
+                fixture.safeFormatValue("[{\"category\": \"reference\",\"nested\": {\"price\": 8.95,\"category\": \"reference\"}}]").replace("\r", ""));
         assertEquals(expected,
-                fixture.safeFormatValue(" [{\"category\": \"reference\",\"nested\": {\"category\": \"reference\",\"price\": 8.95}}] ").replace("\r", ""));
-        assertEquals("<pre>[[]]</pre>",
+                fixture.safeFormatValue(" [{\"category\": \"reference\",\"nested\": {\"price\": 8.95,\"category\": \"reference\"}}] ").replace("\r", ""));
+        assertEquals("<pre>[\n  []\n]</pre>",
                 fixture.safeFormatValue(" [[]] ").replace("\r", ""));
     }
 
@@ -125,6 +127,6 @@ public class JsonHttpTestTest {
         XmlHttpResponse req1 = checkCall(url -> jsonHttpTestTest.deleteWithValuesAsJson(url));
         assertEquals("DELETE", jsonHttpTestTest.getResponse().getMethod());
         assertEquals("DELETE", req1.getMethod());
-        assertEquals("{\"d\":\"4\",\"C\":\"3\"}", req1.getRequest());
+        assertEquals("{\"C\":\"3\",\"d\":\"4\"}", req1.getRequest());
     }
 }

--- a/src/test/java/nl/hsac/fitnesse/fixture/util/JsonHelperTest.java
+++ b/src/test/java/nl/hsac/fitnesse/fixture/util/JsonHelperTest.java
@@ -21,10 +21,10 @@ public class JsonHelperTest {
     public void testFormatSimple() {
         assertEquals(
                 "{\n" +
-                        "    \"price\": 8.95,\n" +
-                        "    \"category\": \"reference\"\n" +
+                        "  \"price\": 8.95,\n" +
+                        "  \"category\": \"reference\"\n" +
                         "}",
-                helper.format("{\"category\": \"reference\",\"price\": 8.95}"));
+                helper.format("{\"price\": 8.95,\"category\": \"reference\"}"));
     }
 
     @Test
@@ -58,17 +58,17 @@ public class JsonHelperTest {
                 "}", "$.parameters", "$.category");
 
         assertEquals("{\n" +
-                        "    \"extraKey\": 2,\n" +
-                        "    \"parameters\": [\n" +
-                        "        {\n" +
-                        "            \"price\": 18.95,\n" +
-                        "            \"category\": \"areference\"\n" +
-                        "        },\n" +
-                        "        {\n" +
-                        "            \"price\": 8.95,\n" +
-                        "            \"category\": \"reference\"\n" +
-                        "        }\n" +
-                        "    ]\n" +
+                        "  \"extraKey\": 2,\n" +
+                        "  \"parameters\": [\n" +
+                        "    {\n" +
+                        "      \"price\": 18.95,\n" +
+                        "      \"category\": \"areference\"\n" +
+                        "    },\n" +
+                        "    {\n" +
+                        "      \"price\": 8.95,\n" +
+                        "      \"category\": \"reference\"\n" +
+                        "    }\n" +
+                        "  ]\n" +
                         "}",
                 helper.format(h));
     }
@@ -90,17 +90,17 @@ public class JsonHelperTest {
                 "}", "$.parameters", "$.price");
 
         assertEquals("{\n" +
-                        "    \"extraKey\": 2,\n" +
-                        "    \"parameters\": [\n" +
-                        "        {\n" +
-                        "            \"price\": 8.95,\n" +
-                        "            \"category\": \"reference\"\n" +
-                        "        },\n" +
-                        "        {\n" +
-                        "            \"price\": 18.95,\n" +
-                        "            \"category\": \"areference\"\n" +
-                        "        }\n" +
-                        "    ]\n" +
+                        "  \"extraKey\": 2,\n" +
+                        "  \"parameters\": [\n" +
+                        "    {\n" +
+                        "      \"price\": 8.95,\n" +
+                        "      \"category\": \"reference\"\n" +
+                        "    },\n" +
+                        "    {\n" +
+                        "      \"price\": 18.95,\n" +
+                        "      \"category\": \"areference\"\n" +
+                        "    }\n" +
+                        "  ]\n" +
                         "}",
                 helper.format(h));
     }

--- a/src/test/java/nl/hsac/fitnesse/fixture/util/JsonHelperTest.java
+++ b/src/test/java/nl/hsac/fitnesse/fixture/util/JsonHelperTest.java
@@ -1,6 +1,7 @@
 package nl.hsac.fitnesse.fixture.util;
 
 import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -57,7 +58,7 @@ public class JsonHelperTest {
                 "  ]\n" +
                 "}", "$.parameters", "$.category");
 
-        assertEquals("{\n" +
+        JSONAssert.assertEquals("{\n" +
                         "  \"extraKey\": 2,\n" +
                         "  \"parameters\": [\n" +
                         "    {\n" +
@@ -70,7 +71,7 @@ public class JsonHelperTest {
                         "    }\n" +
                         "  ]\n" +
                         "}",
-                helper.format(h));
+                helper.format(h), false);
     }
 
     @Test
@@ -89,7 +90,7 @@ public class JsonHelperTest {
                 "  ]\n" +
                 "}", "$.parameters", "$.price");
 
-        assertEquals("{\n" +
+        JSONAssert.assertEquals("{\n" +
                         "  \"extraKey\": 2,\n" +
                         "  \"parameters\": [\n" +
                         "    {\n" +
@@ -102,7 +103,7 @@ public class JsonHelperTest {
                         "    }\n" +
                         "  ]\n" +
                         "}",
-                helper.format(h));
+                helper.format(h),false);
     }
 
     @Test

--- a/src/test/java/nl/hsac/fitnesse/fixture/util/XmlHttpResponseTest.java
+++ b/src/test/java/nl/hsac/fitnesse/fixture/util/XmlHttpResponseTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -159,9 +160,9 @@ public class XmlHttpResponseTest {
         String expected = SoapCallMapColumnFixture.NO_ESCAPE_PREFIX
                             + "NOK:\n<ul>\n"
                             + " <li>amount: 12 <> 158.86</li>\n"
+                            + " <li>result: 1 <> 13.44</li>\n"
                             + " <li>unknownKey: null <> OK</li>\n"
                             + " <li>status: OK <> null</li>\n"
-                            + " <li>result: 1 <> 13.44</li>\n"
                             + "</ul>";
         XPathCheckResult checkResult = resp.checkXPaths(values, expressionsToCheck);
         assertEquals("NOK", checkResult.getResult());
@@ -169,7 +170,7 @@ public class XmlHttpResponseTest {
     }
 
     private Map<String, String> createExprToCheck() {
-        Map<String, String> expressionsToCheck = new HashMap<String, String>();
+        Map<String, String> expressionsToCheck = new LinkedHashMap();
         expressionsToCheck.put("//*[local-name()='amountPremiumYear']", "amount");
         expressionsToCheck.put("//*[local-name()='calculatedResult']", "result");
         return expressionsToCheck;


### PR DESCRIPTION
The following 10 tests:
`nl.hsac.fitnesse.fixture.slim.JsonHttpTestTest#testPutValuesAsJson`
`nl.hsac.fitnesse.fixture.slim.JsonHttpTestTest#testPostValuesAsJson`
`nl.hsac.fitnesse.fixture.slim.JsonHttpTestTest#testDeleteValuesAsJson`

`nl.hsac.fitnesse.fixture.slim.JsonHttpTestTest#testFormatJson`
`nl.hsac.fitnesse.fixture.slim.JsonHttpTestTest#testFormatJsonArray`
`nl.hsac.fitnesse.fixture.util.JsonHelperTest#testFormatSimple`

`nl.hsac.fitnesse.fixture.util.JsonHelperTest#testSortingOnNumber` 
`nl.hsac.fitnesse.fixture.util.JsonHelperTest#testSortingOnString`

`nl.hsac.fitnesse.fixture.util.XmlHttpResponseTest#testCheckXPathsIncorrect`

`nl.hsac.fitnesse.fixture.util.NamespaceContextImplTest#testAddMultipleGet`

are flaky tests. The first 3 tests depend on a function called `jsonEncodeCurrentValues()` in `JsonHttpTest.java` . While debugging, we found out that `JSONObject` was changing the order of the `LinkedHashMap`. As a result, to guarantee the insertion order, the `Gson` library was used instead of `JSONObject`. This library will now convert the ordered map into an ordered string.
More details can be read here:
https://stackoverflow.com/questions/29491281/building-ordered-json-string-from-linkedhashmap

The next 3 tests depend on a function called format() in JsonHelper.java. While debugging, we found out that JSONObject was changing the order of the LinkedHashMap. As a result, to guarantee the order, the `Gson` library was used instead of `JSONObject`. 

The next 2 tests depend on two functions called sort() and format() in JsonHelper.class. While debugging, we found out these tests call `sort()` which calls `sort()` (but with different parameters ) this function calls -> `convertToArray()` then  `jsonStringToMap()` -> `jsonObjectToMap()`. Therefore, during this flow it calls JSONObject  a few times which changed the order object. As a result, instead of `org.junit.Assert.assertEquals` we used `org.skyscreamer.jsonassert.JSONAssert`. 
Skyscreamer's JSONAssert is library which compares jsons but the ordering doesn't matter if the _strict mode_ is false which in this case it is. 
More details can be read here:
https://github.com/skyscreamer/JSONassert
https://stackoverflow.com/questions/2253750/testing-two-json-objects-for-equality-ignoring-child-order-in-java

The 2nd to last flaky test called `testCheckXPathsIncorrect()` in  `XmlHttpResponseTest.java` depends on a helper method called `createExprToCheck()` which creates a HashMap<String, String>.  However,  the order of `amount`, `result`, `unknownKey`,  and `status` is not guaranteed. To guarantee insertion order, the HashMap is changed to a LinkedHashMap in createExprToCheck() which is the root cause of flakiness. 

Lasty, the last flaky tests `testAddMultipleGet` in `NamespaceContextImplTest.java` also didn't gaurantee order. Therefore, changed `HashMap` to `LinkedHashMap` in class `NamespaceContextImpl.java` which initializes a HashMap and where the root cause is for nondeterministic ordering.

Build and unit tests pass:
![Screen Shot 2020-11-15 at 10 53 15 PM](https://user-images.githubusercontent.com/8763964/99214786-b62e5700-2796-11eb-80b4-66842a8ce18a.png)

