### PR TITLE
Update to latest toolchain-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
 		<hsac-fitnesse-plugin.version>1.30.0</hsac-fitnesse-plugin.version>
 		<fitnesse.version>20201213</fitnesse.version>
-		<praegus-toolchain-fitnesse-plugin.version>2.0.10</praegus-toolchain-fitnesse-plugin.version>
+		<praegus-toolchain-fitnesse-plugin.version>2.0.11</praegus-toolchain-fitnesse-plugin.version>
 		<selenium.version>3.141.59</selenium.version>
 		<slf4j.version>1.7.25</slf4j.version>
 		<apache.http.version>4.5.13</apache.http.version>


### PR DESCRIPTION
The currently included version 2.0.10 is *not compatible* with the parser changes in FitNesse 20201213. 
Version 2.0.11 is.