### PR TITLE
Update praegus plugin to 2.0.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
 		<hsac-fitnesse-plugin.version>1.30.0</hsac-fitnesse-plugin.version>
 		<fitnesse.version>20201213</fitnesse.version>
-		<praegus-toolchain-fitnesse-plugin.version>2.0.11</praegus-toolchain-fitnesse-plugin.version>
+		<praegus-toolchain-fitnesse-plugin.version>2.0.12</praegus-toolchain-fitnesse-plugin.version>
 		<selenium.version>3.141.59</selenium.version>
 		<slf4j.version>1.7.25</slf4j.version>
 		<apache.http.version>4.5.13</apache.http.version>


### PR DESCRIPTION
[Plugin v2.0.12](https://github.com/praegus/toolchain-fitnesse-plugin/releases/tag/toolchain-fitnesse-plugin-2.0.12)
Contains Bootstrap-plus 2.0.14:

- Autocomplete now suggests all symbols from toolchain-plugin and hsac-plugin with their parameters
- Add option to sidepbar to pin a certain page as sidebar's root for testsuites with larger depth
- Add keyboard navigation to sidebar. Use arrow keys to navigate and expand/collapse. Open page with enter
- Allow NoLinksTables from FitNesse 20201213 in validator/context lookup
- Small styling improvements to scenario's in Context helper