### PR TITLE
update chrome and edgedriver to latest stable versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,8 @@
 
 		<webdriver.download.skip>false</webdriver.download.skip>
 		<selenium.internetexplorerdriver.version>3.150.1</selenium.internetexplorerdriver.version>
-		<selenium.edgedriver.version>96.0.1054.29</selenium.edgedriver.version>
-		<selenium.chromedriver.version>96.0.4664.45</selenium.chromedriver.version>
+		<selenium.edgedriver.version>96.0.1054.62</selenium.edgedriver.version>
+		<selenium.chromedriver.version>97.0.4692.71</selenium.chromedriver.version>
 		<selenium.geckodriver.version>0.30.0</selenium.geckodriver.version>
 
 		<!-- classpath that Fitnesse uses when not starting from IDE/maven -->


### PR DESCRIPTION
4.30.0 is now failing with chrome 97, as it bundles chromedriver 95