### PR TITLE
Add missing break to switch branch

### DIFF
--- a/src/main/java/nl/hsac/fitnesse/fixture/util/selenium/driverfactory/LocalDriverFactory.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/selenium/driverfactory/LocalDriverFactory.java
@@ -176,6 +176,7 @@ public class LocalDriverFactory implements DriverFactory {
                     } else {
                         throw new IllegalArgumentException("Proxy object is expected to be a map");
                     }
+                    break;
                 default:
                     options.setExperimentalOption(profileEntry.getKey(), profileEntry.getValue());
             }


### PR DESCRIPTION
Missing break causes fall-through to default, which causes an error starting the browser when specifying a proxy server.