### PR TITLE
Use docker base images also available on arm64

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,7 +77,7 @@ build-test-images:
       --context $CI_PROJECT_DIR/docker/chrome
       --dockerfile $CI_PROJECT_DIR/docker/chrome/Dockerfile
       --destination ${CHROME_IMAGE}
-      --build-arg SELENIUM_VERSION=${SELENIUM_VERSION}
+      --build-arg SELENIUM_IMAGE=seleniarm/standalone-chromium:${SELENIUM_VERSION}
       --build-arg TEST_IMAGE=${TEST_IMAGE}
 
 build-combine-image:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,7 @@ before_script:
   - CHROME_PDF_IMAGE=${CI_REGISTRY_IMAGE}/fitnesse-fixtures-test-jre8-chrome-with-pdf:temp-${CI_PIPELINE_ID}
 
 .mvn: &mvn
-  image: maven:3.6-amazoncorretto-8
+  image: maven:3.8-amazoncorretto-8
   cache:
     paths:
       - .m2/repository

--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,9 @@ An example of Maven based project using this baseline can be found at: https://g
 When upgrading from an older version, ensure all Selenium webdrivers are stopped and delete the 'wiki/plugins' and 'wiki/webdrivers' folders to remove old versions of the packaged plugins/webdrivers. When using the sample project: follow the instructions at https://github.com/fhoeben/sample-fitnesse-project#upgrading.
 
 New in ${VERSION}
+- Updated docker images to use base images that are also available on `arm64` platform
+
+New in 5.2.24
 - FitNesse 20221219
 - Selenium 4.7.2
 - hsac-fitnesse-plugin 1.32.10

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG  MAVEN_VERSION=3.6-amazoncorretto-8
+ARG  MAVEN_VERSION=3.8-amazoncorretto-8
 FROM maven:${MAVEN_VERSION} as build
 RUN mkdir -p /usr/src
 WORKDIR /usr/src

--- a/docker/chrome/Dockerfile
+++ b/docker/chrome/Dockerfile
@@ -1,8 +1,8 @@
 ARG  TEST_IMAGE=hsac/fitnesse-fixtures-test-jre8:latest
-ARG  SELENIUM_VERSION=4.7.2
+ARG  SELENIUM_IMAGE=seleniarm/standalone-chromium:latest
 FROM ${TEST_IMAGE} as hsac-fixtures
 
-FROM selenium/standalone-chrome:${SELENIUM_VERSION}
+FROM ${SELENIUM_IMAGE}
 RUN sudo mv /etc/supervisor/conf.d/selenium.conf /etc/supervisor/conf.d/selenium.conf.bak && \
     sudo mkdir -p /fitnesse/target && \
     sudo mkdir -p /fitnesse/wiki/webdrivers && \

--- a/docker/chrome/Dockerfile
+++ b/docker/chrome/Dockerfile
@@ -18,7 +18,7 @@ VOLUME /fitnesse/wiki/FitNesseRoot
 
 ENV FITNESSE_OPTS -Djava.security.egd=file:/dev/./urandom -Djava.awt.headless=true \
     -DseleniumBrowser=chrome \
-    -DseleniumJsonProfile="{'args':['--disable-dev-shm-usage']}"
+    -DseleniumJsonProfile="{'args':['disable-dev-shm-usage']}"
 
 ENTRYPOINT ["/fitnesse/startGridAndRunTests.sh"]
 CMD []

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -1,5 +1,5 @@
 ARG  BASE_IMAGE=hsac/fitnesse-fixtures-test-jre8:base-latest
-ARG  JRE_IMAGE=amazoncorretto:8-alpine-jre
+ARG  JRE_IMAGE=eclipse-temurin:8-jre
 
 FROM ${BASE_IMAGE} as base
 

--- a/docker/test/Dockerfile-local
+++ b/docker/test/Dockerfile-local
@@ -1,4 +1,4 @@
-ARG  JRE_IMAGE=amazoncorretto:8-alpine-jre
+ARG  JRE_IMAGE=eclipse-temurin:8-jre
 
 FROM ${JRE_IMAGE}
 RUN mkdir -p /fitnesse/wiki/fixtures/nl/hsac/fitnesse


### PR DESCRIPTION
By using docker base images also available on arm64 it becomes possible to build for AWS graviton or Mac M1 processors without changing the docker files 