### PR TITLE
Chromedriver for windows zip now has >1 file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,7 @@
 							<bit>32</bit>
 							<version>${selenium.chromedriver.version}</version>
 							<url>http://chromedriver.storage.googleapis.com/${selenium.chromedriver.version}/chromedriver_win32.zip</url>
+							<fileMatchInside>chromedriver.exe</fileMatchInside>
 						</driver>
 						<driver>
 							<name>chromedriver</name>


### PR DESCRIPTION
Extract only executable to prevent subdirectory to be created inside webdrivers folder (breaking chrome tests in windows)