### PR TITLE
Fix bug for FileFixture.setDirectory("http://files/test")

### DIFF
--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/FileFixture.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/FileFixture.java
@@ -26,7 +26,7 @@ public class FileFixture extends SlimFixtureWithMap {
     public void setDirectory(String aDirectory) {
         if (isFilesUrl(aDirectory)) {
             String url = getUrl(aDirectory);
-            String relativeDir = url.substring("files".length());
+            String relativeDir = url.substring(url.indexOf("files") + "files".length());
             relativeDir = relativeDir.replace('/', File.separatorChar);
             directory = filesDir + relativeDir;
         } else {

--- a/src/test/java/nl/hsac/fitnesse/fixture/slim/FileFixtureTest.java
+++ b/src/test/java/nl/hsac/fitnesse/fixture/slim/FileFixtureTest.java
@@ -40,6 +40,22 @@ public class FileFixtureTest {
     }
 
     @Test
+    public void testSetAndGetDirectoryHttpFilesTest() {
+        String defaultFilesDir = Environment.getInstance().getFitNesseFilesSectionDir();
+        fixture.setDirectory("http://files/test");
+        String expected = new File(defaultsFilesDir, "test").getAbsolutePath() + File.separator;
+        assertEquals(expected, fixture.getDirectory());
+    }
+
+    @Test
+    public void testSetAndGetDirectoryHttpFilesTestAnchor() {
+        String defaultFilesDir = Environment.getInstance().getFitNesseFilesSectionDir();
+        fixture.setDirectory("<a href="files/test">http://files/test</a>");
+        String expected = new File(defaultsFilesDir, "test").getAbsolutePath() + File.separator;
+        assertEquals(expected, fixture.getDirectory());
+    }
+
+    @Test
     public void testExists() {
         fixture.setDirectory(testResourcesDir);
         assertTrue(fixture.exists(txtFilename));

--- a/src/test/java/nl/hsac/fitnesse/fixture/slim/FileFixtureTest.java
+++ b/src/test/java/nl/hsac/fitnesse/fixture/slim/FileFixtureTest.java
@@ -50,7 +50,7 @@ public class FileFixtureTest {
     @Test
     public void testSetAndGetDirectoryHttpFilesTestAnchor() {
         String defaultFilesDir = Environment.getInstance().getFitNesseFilesSectionDir();
-        fixture.setDirectory("<a href="files/test">http://files/test</a>");
+        fixture.setDirectory("<a href=\"files/test\">http://files/test</a>");
         String expected = new File(defaultsFilesDir, "test").getAbsolutePath() + File.separator;
         assertEquals(expected, fixture.getDirectory());
     }

--- a/src/test/java/nl/hsac/fitnesse/fixture/slim/FileFixtureTest.java
+++ b/src/test/java/nl/hsac/fitnesse/fixture/slim/FileFixtureTest.java
@@ -43,7 +43,7 @@ public class FileFixtureTest {
     public void testSetAndGetDirectoryHttpFilesTest() {
         String defaultFilesDir = Environment.getInstance().getFitNesseFilesSectionDir();
         fixture.setDirectory("http://files/test");
-        String expected = new File(defaultsFilesDir, "test").getAbsolutePath() + File.separator;
+        String expected = new File(defaultFilesDir, "test").getAbsolutePath() + File.separator;
         assertEquals(expected, fixture.getDirectory());
     }
 
@@ -51,7 +51,7 @@ public class FileFixtureTest {
     public void testSetAndGetDirectoryHttpFilesTestAnchor() {
         String defaultFilesDir = Environment.getInstance().getFitNesseFilesSectionDir();
         fixture.setDirectory("<a href=\"files/test\">http://files/test</a>");
-        String expected = new File(defaultsFilesDir, "test").getAbsolutePath() + File.separator;
+        String expected = new File(defaultFilesDir, "test").getAbsolutePath() + File.separator;
         assertEquals(expected, fixture.getDirectory());
     }
 


### PR DESCRIPTION
Fix bug in FileFixture.setDirectory(String)  for argument "http://files/test" .

Bug can be observed throught script:
<pre>
|Import                       |
|nl.hsac.fitnesse.fixture.slim|

|script       |file fixture     |
|set directory|http://files/test|
|show         |get directory    |

^|script|
|set  directory|http://files/test|
|show          |get directory    |
</pre>

For my project, the first set directory/get directory will show
`     C:\git\toolchain\wiki\FitNesseRoot\files\test\`
and the second one shows
`     C:\git\toolchain\wiki\FitNesseRoot\files\\files\test\`

The first one is right.
The difference comes from the fact that the first call to setDirectory() gets argument `<a href="files/test">http://files/test</a>` .

In the code, for the second call to setDirectory() :
<pre>
    public void setDirectory(String aDirectory) {
        if (this.isFilesUrl(aDirectory)) {
            String url = this.getUrl(aDirectory);
            String relativeDir = url.substring("files".length());             <<<<< goes wrong for url: http://files/test
            relativeDir = relativeDir.replace('/', File.separatorChar);
            this.directory = this.filesDir + relativeDir;
        } else if ((new File(aDirectory)).isAbsolute()) {
            this.directory = aDirectory;
        } else {
            this.directory = (new File(this.getEnvironment().getFitNesseDir(), aDirectory)).getAbsolutePath();
        }

        if (!this.directory.endsWith(File.separator)) {
            this.directory = this.directory + File.separator;
        }

    }
</pre>
Line
<pre>            String relativeDir = url.substring("files".length());</pre>
for url `http://files/test`  should produce `/test` but it doesn't.

Replace
<pre>            String relativeDir = url.substring("files".length());</pre>
by
<pre>            String relativeDir = url.substring(url.indexOf("files") + "files".length());</pre>


