### PR TITLE
Shorthand method to start a selenium-managed driver

### DIFF
--- a/src/main/java/nl/hsac/fitnesse/fixture/slim/web/SeleniumDriverSetup.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/slim/web/SeleniumDriverSetup.java
@@ -4,6 +4,7 @@ import nl.hsac.fitnesse.fixture.Environment;
 import nl.hsac.fitnesse.fixture.slim.SlimFixture;
 import nl.hsac.fitnesse.fixture.util.selenium.SauceLabsHelper;
 import nl.hsac.fitnesse.fixture.util.selenium.SeleniumHelper;
+import nl.hsac.fitnesse.fixture.util.selenium.driverfactory.DriverClassNames;
 import nl.hsac.fitnesse.fixture.util.selenium.driverfactory.DriverFactory;
 import nl.hsac.fitnesse.fixture.util.selenium.driverfactory.DriverManager;
 import nl.hsac.fitnesse.fixture.util.selenium.driverfactory.LocalDriverFactory;
@@ -79,6 +80,15 @@ public class SeleniumDriverSetup extends SlimFixture {
      */
     public boolean startDriver(String driverClassName) throws Exception {
         return startDriver(driverClassName, null);
+    }
+
+    public boolean startManagedDriverForWithProfile(String browserName, final Map<String, Object> profile) throws Exception {
+        String driverName = DriverClassNames.getClassNameFor(browserName);
+        return startDriver(driverName, profile);
+    }
+
+    public boolean startManagedDriverFor(String browserName) throws Exception {
+        return startManagedDriverForWithProfile(browserName, null);
     }
 
     /**

--- a/src/main/java/nl/hsac/fitnesse/fixture/util/selenium/driverfactory/DriverClassNames.java
+++ b/src/main/java/nl/hsac/fitnesse/fixture/util/selenium/driverfactory/DriverClassNames.java
@@ -1,0 +1,27 @@
+package nl.hsac.fitnesse.fixture.util.selenium.driverfactory;
+
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.edge.EdgeDriver;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.ie.InternetExplorerDriver;
+import org.openqa.selenium.safari.SafariDriver;
+
+import java.util.Arrays;
+
+public enum DriverClassNames {
+    CHROME(ChromeDriver.class.getName()),
+    EDGE(EdgeDriver.class.getName()),
+    FIREFOX(FirefoxDriver.class.getName()),
+    SAFARI(SafariDriver.class.getName()),
+    INTERNET_EXPLORER(InternetExplorerDriver.class.getName());
+
+    private final String driverClassName;
+    DriverClassNames(String driverClassName) {
+        this.driverClassName = driverClassName;
+    }
+
+    public static String getClassNameFor(String browser) {
+        return Arrays.stream(DriverClassNames.values()).filter(dcn -> dcn.name().equalsIgnoreCase(browser))
+                .findFirst().map(dcn -> dcn.driverClassName).orElse(null);
+    }
+}

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/BrowserTests/SuiteSetUp.wiki
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/BrowserTests/SuiteSetUp.wiki
@@ -46,21 +46,22 @@ This configuration can be overridden by using system properties. This allows dif
 |$ieCleanSession=                      |copy map                          |
 *!
 
-|script          |selenium driver setup                                                                                                                  |
-|start driver for|chrome                                                                                                                                 |
-|note            |start driver for     |!-MicrosoftEdge-!                                                                                                |
-|note            |start driver for     |internet explorer                                                                                                |
-|note            |start driver for     |firefox                                                                                                          |
-|note            |start driver for     |safari                                                                                                           |
-|note            |start driver for     |chrome mobile emulation|with profile          |!{deviceName:Apple iPhone 6}                                      |
-|note            |start driver for     |chrome mobile emulation|with profile          |$mobileEmulation                                                  |
-|note            |start driver for     |chrome                 |with profile          |$chromeHeadlessProfile                                            |
-|note            |Starting internet explorer with a clean session is destructive, i.e. clears cookies, cache, history and saved form data ''globally''   |
-|note            |start driver for     |internet explorer      |with profile          |$ieCleanSession                                                   |
-|note            |connect to driver for|chrome                 |at                    |${GRID_HUB}                                                       |
-|note            |connect to driver for|!-MicrosoftEdge-!      |at                    |${GRID_HUB}                                                       |
-|note            |connect to driver for|internet explorer      |at                    |${GRID_HUB}                                                       |
-|note            |connect to driver for|firefox                |at                    |${GRID_HUB}                                                       |
-|note            |connect to driver at |${GRID_HUB}            |with capabilities     |!{browserName:internet explorer, platform:Windows 8.1, version:11}|
-|note            |connect to driver at |${GRID_HUB}            |with json capabilities|{aut:"io.selendroid.testapp", emulator: true}                     |
-|show            |driver description                                                                                                                     |
+|script                  |selenium driver setup                                                                                                                  |
+|start managed driver for|chrome                                                                                                                                 |
+|note                    |start driver for     |chrome                                                                                                           |
+|note                    |start driver for     |!-MicrosoftEdge-!                                                                                                |
+|note                    |start driver for     |internet explorer                                                                                                |
+|note                    |start driver for     |firefox                                                                                                          |
+|note                    |start driver for     |safari                                                                                                           |
+|note                    |start driver for     |chrome mobile emulation|with profile          |!{deviceName:Apple iPhone 6}                                      |
+|note                    |start driver for     |chrome mobile emulation|with profile          |$mobileEmulation                                                  |
+|note                    |start driver for     |chrome                 |with profile          |$chromeHeadlessProfile                                            |
+|note                    |Starting internet explorer with a clean session is destructive, i.e. clears cookies, cache, history and saved form data ''globally''   |
+|note                    |start driver for     |internet explorer      |with profile          |$ieCleanSession                                                   |
+|note                    |connect to driver for|chrome                 |at                    |${GRID_HUB}                                                       |
+|note                    |connect to driver for|!-MicrosoftEdge-!      |at                    |${GRID_HUB}                                                       |
+|note                    |connect to driver for|internet explorer      |at                    |${GRID_HUB}                                                       |
+|note                    |connect to driver for|firefox                |at                    |${GRID_HUB}                                                       |
+|note                    |connect to driver at |${GRID_HUB}            |with capabilities     |!{browserName:internet explorer, platform:Windows 8.1, version:11}|
+|note                    |connect to driver at |${GRID_HUB}            |with json capabilities|{aut:"io.selendroid.testapp", emulator: true}                     |
+|show                    |driver description                                                                                                                     |


### PR DESCRIPTION
Since selenium 4.6.0, Selenium contains its own [driver manager](https://www.selenium.dev/blog/2022/introducing-selenium-manager/) that can automatically download the right webdriver version for a given browser. This manager can currently be used with selenium driver setup using the `|start driver|<driver class FQN>|` methods (or override from maven using the driverclass.

This, however, is not immediately clear to all users and using the right driver classname is apparently not easy for everyone..
This PR introduces new methods (startManagedDriverFor & startManagedDriverForWithProfile) that derive the driver class name from the readable driver name (chrome, edge, firefox, safari, internet_explorer) and make it explicit that a **selenium managed** driver is desired.

Now, when users would set `<webdriver.download.skip>true</webdriver.download.skip>` in their project's pom.xml and use these methods, they will no longer run into issues with web driver versions getting out of sync when their company laptop auto-updates (or never updates) the browser.

The selenium driver manager works on windows, linux and mac.
Also added this driver usage in the Example SuiteSetUp for BrowserTest to both illustrate the option and prevent users from not being able to run the examples due to browser vs driver incompatibilities.