### PR TITLE
Default to using managed webdriver

### DIFF
--- a/.github/workflows/main-java11.yml
+++ b/.github/workflows/main-java11.yml
@@ -27,12 +27,6 @@ jobs:
           distribution: 'zulu'
           cache: 'maven'
 
-      - name: Update browser
-        run: |
-          wget -q -O /tmp/chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
-          && sudo apt install -y /tmp/chrome.deb \
-          && rm /tmp/chrome.deb
-
       - name: Unsnapshot version
         run:  mvn versions:set -DremoveSnapshot
 

--- a/.github/workflows/other-java11.yml
+++ b/.github/workflows/other-java11.yml
@@ -37,14 +37,8 @@ jobs:
           distribution: 'zulu'
           cache: maven
 
-      - name: Update browser
-        run: |
-          wget -q -O /tmp/chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
-          && sudo apt install -y /tmp/chrome.deb \
-          && rm /tmp/chrome.deb
-
       - name: Test with Maven
-        run: mvn --batch-mode --update-snapshots -DfitnesseSuiteToRun=HsacAcceptanceTests -DseleniumBrowser=chrome "-DseleniumJsonProfile={'args':['headless', 'disable-gpu']}" verify failsafe:verify install
+        run: mvn --batch-mode --update-snapshots -DfitnesseSuiteToRun=HsacAcceptanceTests -DseleniumDriverClass=org.openqa.selenium.chrome.ChromeDriver "-DseleniumJsonProfile={'args':['headless', 'disable-gpu']}" verify failsafe:verify install
 
       - id: get-version
         run: |

--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@ When upgrading from an older version, ensure all Selenium webdrivers are stopped
 
 New in ${VERSION}
 - Support for dynamic on-demand download of Selenium web drivers in 'selenium driver setup', by using `start managed driver for <chrome|edge|firefox|safari>`
+- The '-standalone.zip' artifact of this project no longer includes Selenium web drivers, assuming those will be downloaded by using the managed one. There is a separate package '-standalone-with-webdrivers.zip' that does include webdrivers for Windows and Mac.
 
 New in 5.3.9
 - Selenium 4.17.0

--- a/changelog.md
+++ b/changelog.md
@@ -22,7 +22,7 @@ When upgrading from an older version, ensure all Selenium webdrivers are stopped
 
 New in ${VERSION}
 - Support for dynamic on-demand download of Selenium web drivers in 'selenium driver setup', by using `start managed driver for <chrome|edge|firefox|safari>`
-- The '-standalone.zip' artifact of this project no longer includes Selenium web drivers, assuming those will be downloaded by using the managed one. There is a separate package '-standalone-with-webdrivers.zip' that does include webdrivers for Windows and Mac.
+- The '-standalone.zip' artifact of this project no longer includes Selenium web drivers, assuming those will be downloaded by using the managed one. There is a separate package '-standalone-with-webdrivers.zip' that does include Chrome, Edge and Firefox webdrivers for Windows and Mac.
 
 New in 5.3.9
 - Selenium 4.17.0

--- a/pom.xml
+++ b/pom.xml
@@ -559,11 +559,6 @@
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<version>3.6.0</version>
-				<configuration>
-					<descriptors>
-						<descriptor>src/assembly/standalone.xml</descriptor>
-					</descriptors>
-				</configuration>
 				<executions>
 					<execution>
 						<id>create-standalone-zip</id>
@@ -571,6 +566,23 @@
 						<goals>
 							<goal>single</goal>
 						</goals>
+						<configuration>
+							<descriptors>
+								<descriptor>src/assembly/standalone.xml</descriptor>
+							</descriptors>
+						</configuration>
+					</execution>
+					<execution>
+						<id>create-standalone-with-webdrivers-zip</id>
+						<phase>package</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+						<configuration>
+							<descriptors>
+								<descriptor>src/assembly/standalone-with-webdrivers.xml</descriptor>
+							</descriptors>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -330,6 +330,24 @@
 							<fileMatchInside>msedgedriver.exe</fileMatchInside>
 						</driver>
 						<driver>
+							<name>edgedriver</name>
+							<platform>mac_m1</platform>
+							<bit>64</bit>
+							<version>${selenium.edgedriver.version}</version>
+							<url>
+								https://msedgedriver.azureedge.net/${selenium.edgedriver.version}/edgedriver_mac64_m1.zip</url>
+							<fileMatchInside>msedgedriver</fileMatchInside>
+						</driver>
+						<driver>
+							<name>edgedriver</name>
+							<platform>mac</platform>
+							<bit>64</bit>
+							<version>${selenium.edgedriver.version}</version>
+							<url>
+								https://msedgedriver.azureedge.net/${selenium.edgedriver.version}/edgedriver_mac64.zip</url>
+							<fileMatchInside>msedgedriver</fileMatchInside>
+						</driver>
+						<driver>
 							<name>chromedriver</name>
 							<platform>windows</platform>
 							<bit>64</bit>
@@ -355,15 +373,6 @@
 							<url>
 								https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/${selenium.chromedriver.version}/mac-arm64/chromedriver-mac-arm64.zip</url>
 							<fileMatchInside>chromedriver-mac-arm64/chromedriver</fileMatchInside>
-						</driver>
-						<driver>
-							<name>chromedriver</name>
-							<platform>linux</platform>
-							<bit>64</bit>
-							<version>${selenium.chromedriver.version}</version>
-							<url>
-								https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/${selenium.chromedriver.version}/linux64/chromedriver-linux64.zip</url>
-							<fileMatchInside>chromedriver-linux64/chromedriver</fileMatchInside>
 						</driver>
 						<driver>
 							<name>geckodriver</name>

--- a/pom.xml
+++ b/pom.xml
@@ -375,6 +375,15 @@
 							<fileMatchInside>chromedriver-mac-arm64/chromedriver</fileMatchInside>
 						</driver>
 						<driver>
+							<name>chromedriver</name>
+							<platform>linux</platform>
+							<bit>64</bit>
+							<version>${selenium.chromedriver.version}</version>
+							<url>
+								https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/${selenium.chromedriver.version}/linux64/chromedriver-linux64.zip</url>
+							<fileMatchInside>chromedriver-linux64/chromedriver</fileMatchInside>
+						</driver>
+						<driver>
 							<name>geckodriver</name>
 							<platform>windows</platform>
 							<bit>64</bit>

--- a/src/assembly/standalone-with-webdrivers.xml
+++ b/src/assembly/standalone-with-webdrivers.xml
@@ -25,8 +25,6 @@
             <excludes>
                 <exclude>webdrivers/*.version</exclude>
                 <exclude>webdrivers/*.exe</exclude>
-                <!-- linux webdriver is only included for use by Travis-ci, we don't expect standalone.zip user to run linux -->
-                <exclude>webdrivers/*-linux-*</exclude>
             </excludes>
             <fileMode>0755</fileMode>
         </fileSet>
@@ -35,8 +33,6 @@
             <useDefaultExcludes>true</useDefaultExcludes>
             <outputDirectory></outputDirectory>
             <excludes>
-                <!-- linux webdriver is only included for use by Travis-ci, we don't expect standalone.zip user to run linux -->
-                <exclude>webdrivers/*-linux-*</exclude>
                 <exclude>target/**</exclude>
                 <exclude>copy/**</exclude>
                 <exclude>files/**</exclude>

--- a/src/assembly/standalone-with-webdrivers.xml
+++ b/src/assembly/standalone-with-webdrivers.xml
@@ -1,7 +1,7 @@
 <assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
-    <id>standalone</id>
+    <id>standalone-with-webdrivers</id>
     <formats>
         <format>zip</format>
     </formats>
@@ -19,9 +19,24 @@
             <directory>${project.basedir}/wiki</directory>
             <useDefaultExcludes>true</useDefaultExcludes>
             <outputDirectory></outputDirectory>
+            <includes>
+                <include>webdrivers/*</include>
+            </includes>
+            <excludes>
+                <exclude>webdrivers/*.version</exclude>
+                <exclude>webdrivers/*.exe</exclude>
+                <!-- linux webdriver is only included for use by Travis-ci, we don't expect standalone.zip user to run linux -->
+                <exclude>webdrivers/*-linux-*</exclude>
+            </excludes>
+            <fileMode>0755</fileMode>
+        </fileSet>
+        <fileSet>
+            <directory>${project.basedir}/wiki</directory>
+            <useDefaultExcludes>true</useDefaultExcludes>
+            <outputDirectory></outputDirectory>
             <excludes>
                 <!-- linux webdriver is only included for use by Travis-ci, we don't expect standalone.zip user to run linux -->
-                <exclude>webdrivers/**</exclude>
+                <exclude>webdrivers/*-linux-*</exclude>
                 <exclude>target/**</exclude>
                 <exclude>copy/**</exclude>
                 <exclude>files/**</exclude>

--- a/src/assembly/standalone-with-webdrivers.xml
+++ b/src/assembly/standalone-with-webdrivers.xml
@@ -25,6 +25,8 @@
             <excludes>
                 <exclude>webdrivers/*.version</exclude>
                 <exclude>webdrivers/*.exe</exclude>
+                <!-- linux webdriver is only included so we can test whether we can find local driver in CI run, we don't expect standalone.zip user to run linux -->
+                <exclude>webdrivers/*-linux-*</exclude>
             </excludes>
             <fileMode>0755</fileMode>
         </fileSet>
@@ -33,6 +35,8 @@
             <useDefaultExcludes>true</useDefaultExcludes>
             <outputDirectory></outputDirectory>
             <excludes>
+                <!-- linux webdriver is only included so we can test whether we can find local driver in CI run, we don't expect standalone.zip user to run linux -->
+                <exclude>webdrivers/*-linux-*</exclude>
                 <exclude>target/**</exclude>
                 <exclude>copy/**</exclude>
                 <exclude>files/**</exclude>

--- a/src/assembly/standalone.xml
+++ b/src/assembly/standalone.xml
@@ -20,7 +20,6 @@
             <useDefaultExcludes>true</useDefaultExcludes>
             <outputDirectory></outputDirectory>
             <excludes>
-                <!-- linux webdriver is only included for use by Travis-ci, we don't expect standalone.zip user to run linux -->
                 <exclude>webdrivers/**</exclude>
                 <exclude>target/**</exclude>
                 <exclude>copy/**</exclude>

--- a/wiki/FitNesseRoot/HsacExamples/SlimTests/BrowserTests/SuiteSetUp.wiki
+++ b/wiki/FitNesseRoot/HsacExamples/SlimTests/BrowserTests/SuiteSetUp.wiki
@@ -46,25 +46,25 @@ This configuration can be overridden by using system properties. This allows dif
 |$ieCleanSession=                      |copy map                          |
 *!
 
-|script          |selenium driver setup                                                                                                                     |
-|start driver for|chrome                                                                                                                                    |
-|note            |start driver for        |!-MicrosoftEdge-!                                                                                                |
-|note            |start driver for        |internet explorer                                                                                                |
-|note            |start driver for        |firefox                                                                                                          |
-|note            |start driver for        |safari                                                                                                           |
-|note            |start managed driver for|chrome                                                                                                           |
-|note            |start managed driver for|edge                                                                                                             |
-|note            |start managed driver for|firefox                                                                                                          |
-|note            |start managed driver for|safari                                                                                                           |
-|note            |start driver for        |chrome mobile emulation|with profile          |!{deviceName:Apple iPhone 6}                                      |
-|note            |start driver for        |chrome mobile emulation|with profile          |$mobileEmulation                                                  |
-|note            |start driver for        |chrome                 |with profile          |$chromeHeadlessProfile                                            |
-|note            |Starting internet explorer with a clean session is destructive, i.e. clears cookies, cache, history and saved form data ''globally''      |
-|note            |start driver for        |internet explorer      |with profile          |$ieCleanSession                                                   |
-|note            |connect to driver for   |chrome                 |at                    |${GRID_HUB}                                                       |
-|note            |connect to driver for   |!-MicrosoftEdge-!      |at                    |${GRID_HUB}                                                       |
-|note            |connect to driver for   |internet explorer      |at                    |${GRID_HUB}                                                       |
-|note            |connect to driver for   |firefox                |at                    |${GRID_HUB}                                                       |
-|note            |connect to driver at    |${GRID_HUB}            |with capabilities     |!{browserName:internet explorer, platform:Windows 8.1, version:11}|
-|note            |connect to driver at    |${GRID_HUB}            |with json capabilities|{aut:"io.selendroid.testapp", emulator: true}                     |
-|show            |driver description                                                                                                                        |
+|script                  |selenium driver setup                                                                                                                     |
+|note                    |start driver for        |chrome                                                                                                           |
+|note                    |start driver for        |!-MicrosoftEdge-!                                                                                                |
+|note                    |start driver for        |internet explorer                                                                                                |
+|note                    |start driver for        |firefox                                                                                                          |
+|note                    |start driver for        |safari                                                                                                           |
+|start managed driver for|chrome                                                                                                                                    |
+|note                    |start managed driver for|edge                                                                                                             |
+|note                    |start managed driver for|firefox                                                                                                          |
+|note                    |start managed driver for|safari                                                                                                           |
+|note                    |start driver for        |chrome mobile emulation|with profile          |!{deviceName:Apple iPhone 6}                                      |
+|note                    |start driver for        |chrome mobile emulation|with profile          |$mobileEmulation                                                  |
+|note                    |start driver for        |chrome                 |with profile          |$chromeHeadlessProfile                                            |
+|note                    |Starting internet explorer with a clean session is destructive, i.e. clears cookies, cache, history and saved form data ''globally''      |
+|note                    |start driver for        |internet explorer      |with profile          |$ieCleanSession                                                   |
+|note                    |connect to driver for   |chrome                 |at                    |${GRID_HUB}                                                       |
+|note                    |connect to driver for   |!-MicrosoftEdge-!      |at                    |${GRID_HUB}                                                       |
+|note                    |connect to driver for   |internet explorer      |at                    |${GRID_HUB}                                                       |
+|note                    |connect to driver for   |firefox                |at                    |${GRID_HUB}                                                       |
+|note                    |connect to driver at    |${GRID_HUB}            |with capabilities     |!{browserName:internet explorer, platform:Windows 8.1, version:11}|
+|note                    |connect to driver at    |${GRID_HUB}            |with json capabilities|{aut:"io.selendroid.testapp", emulator: true}                     |
+|show                    |driver description                                                                                                                        |


### PR DESCRIPTION
No longer bundle webdrivers in -standalone.zip, default to using the Selenium managed download that will download the proper webdriver on demand the first time it is used and will download one matching the installed browser version.

Add a separate -standalone-with-webdrivers.zip, which does include downloaded webdrivers as before. This package also contains drivers for Edge on MacOS (both Apple silicon and Intel)