### PR TITLE
Remove acceptance tests failing on GitHub 

### DIFF
--- a/wiki/FitNesseRoot/HsacAcceptanceTests/SlimTests/BrowserTest/ClickEmptySelectOption.wiki
+++ b/wiki/FitNesseRoot/HsacAcceptanceTests/SlimTests/BrowserTest/ClickEmptySelectOption.wiki
@@ -23,33 +23,6 @@ Test
 		<option>4</option>
 	</select>
 </label>
-
-<label>Nested empty option
-	<select id="3">
-		<option><span></span></option>
-		<option>2</option>
-		<option>3</option>
-		<option>4</option>
-	</select>
-</label>
-
-<label>Nested whitespace option
-	<select id="4">
-		<option><span> </span></option>
-		<option>2</option>
-		<option>3</option>
-		<option>4</option>
-	</select>
-</label>
-
-<label>Multiple nested whitespace options
-	<select id="5">
-		<option><span> <span> <span> </span></option>
-		<option>2</option>
-		<option>3</option>
-		<option>4</option>
-	</select>
-</label>
 </body>
 </html>}}} }
 
@@ -70,9 +43,6 @@ Test
 |seconds before timeout|1                     |
 |check select          |id=1|with empty option|
 |check select          |id=2|with empty option|
-|check select          |id=3|with empty option|
-|check select          |id=4|with empty option|
-|check select          |id=5|with empty option|
 
 |script|mock xml server setup|
 |stop                        |

--- a/wiki/FitNesseRoot/HsacAcceptanceTests/SlimTests/BrowserTest/SelectHandlingTest.wiki
+++ b/wiki/FitNesseRoot/HsacAcceptanceTests/SlimTests/BrowserTest/SelectHandlingTest.wiki
@@ -59,12 +59,8 @@ This test ensures we can work with select boxes. We use a mock server running to
 |check                 |value of                                              |Options to choose               |!-example3@example.com-!                              |
 |select                |example4@example.com                                  |for                             |Complex options to choose                             |
 |check                 |value of                                              |Complex options to choose       |!-example4@example.com-! is another to choose         |
-|select                |first                                                 |for                             |Complex options to choose                             |
-|check                 |value of                                              |Complex options to choose       |a mail to !-example1@example.com-! is the first option|
 |select                |to choose                                             |for                             |Complex options to choose                             |
 |check                 |value of                                              |Complex options to choose       |!-example4@example.com-! is another to choose         |
-|select                |a mail to !-example1@example.com-! is the first option|for                             |Complex options to choose                             |
-|check                 |value of                                              |Complex options to choose       |a mail to !-example1@example.com-! is the first option|
 |check                 |value of                                              |Multiple text nodes in an option|3rd option                                            |
 |select                |Option text                                           |for                             |Multiple text nodes in an option                      |
 |check                 |value of                                              |Multiple text nodes in an option|Option text                                           |


### PR DESCRIPTION
Apparently finding nested `span` elements inside a `select`'s `option` tags no longer works on Linux Chrome, versions 129 and higher.

This failed the acceptance tests on GitHub, #691.

[According to the HTML spec such elements are actually not allowed](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option#technical_summary). So I removed those tests.
The functionality does still work on Mac M1, with chrome 131. For this reason I did not actually remove the functionality to attempt to find such elements from the code.
